### PR TITLE
Cli-auth-docs

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -1,9 +1,9 @@
-## Модуль config
+## Config module
 
-### Назначение
-Парсинг и валидация YAML-конфигурации приложения (клиент реестра + диспетчер). Загрузка — `ConfigLoader`, правила — `ConfigValidator`.
+### Purpose
+Parse and validate the application YAML config (registry client + dispatcher). Loader: `ConfigLoader`, rules: `ConfigValidator`.
 
-### Минимальный валидный пример
+### Minimal valid example
 ```yaml
 client:
   http: {}
@@ -17,7 +17,7 @@ dispatcher:
   maxConcurrentRegistry: 1
 ```
 
-### Дефолты (по выводу smoke-теста)
+### Defaults (from smoke test)
 - client.http.connectTimeout = PT5S
 - client.http.requestTimeout = PT30S
 - client.http.maxRetries = 0
@@ -30,17 +30,17 @@ dispatcher:
 - client.auth.certPath / keyPath / caPath = null
 - client.registries.size = 1
 
-### Правила валидации (ConfigValidator)
-- Обязательны `client`, `dispatcher`, `registries`; минимум один registry с `scheme` и `host`.
+### Validation rules (ConfigValidator)
+- `client`, `dispatcher`, `registries` required; at least one registry with `scheme` and `host`.
 - `dispatcher.maxConcurrentRegistry` > 0.
-- `client.http`: таймауты/бэкоффы > 0, `initialBackoff <= maxBackoff`, `userAgent` не пустой, `maxRetries` < 0 запрещён (валидация падает).
-- `client.auth.defaultTokenTtlSeconds` > 0; пути cert/key/ca, если заданы, должны существовать.
+- `client.http`: timeouts/backoff > 0, `initialBackoff <= maxBackoff`, `userAgent` not blank, `maxRetries` must be >= 0.
+- `client.auth.defaultTokenTtlSeconds` > 0; cert/key/ca paths, if provided, must exist.
 
-### Известные особенности
-- Отсутствие `registries` приводит к `ConfigValidationException`.
+### Known notes
+- Missing `registries` throws `ConfigValidationException`.
 
-### Тесты
-- `ConfigBranchTest`: ветвления валидации (включая maxRetries < 0, отсутствие http/auth/registries/dispatcher).
-- `ConfigLoaderTest` (integration/config_client): загрузка/валидация файлов.
-- Smoke: `smokePrintsDefaultsFromMinimalConfig` — печать фактических дефолтов после загрузки минимального валидного YAML.
+### Tests
+- `ConfigBranchTest`: validation branches (including maxRetries < 0, missing http/auth/registries/dispatcher).
+- `ConfigLoaderTest` (integration/config_client): loading/validation from files.
+- Smoke: `smokePrintsDefaultsFromMinimalConfig` — prints actual defaults after loading minimal valid YAML.
 

--- a/docs/test.md
+++ b/docs/test.md
@@ -1,4 +1,19 @@
-# Structure:
-<modulename> <- test which run exactly classes in module. Consider to refactor it to internal/<modulename> but tests use package private names
-integration/<directory> <- tests checked many modules. (have Clashes with package-private conception of Java)
-e2e/ <- end-to-end tests
+# Tests layout and how to run
+
+## Layers
+- `src/test/java/<module>/...`: unit tests scoped to a single module/package (keep package-private helpers close to code).
+- `src/test/java/riid/integration/<scope>/...`: cross-module integration (e.g., `runtime_app`, `client_cache`, `config_client`, `dispatcher_*`). Use this for multimodule flows and live registry/runtime checks.
+- `src/test/java/riid/e2e/...`: end-to-end CLI-to-runtime scenarios (minimal, black-box style).
+
+## Tags / long-running
+- Live/registry/podman tests may need network or local runtimes; skip them when offline (e.g., `--exclude-task integrationTest` or selective `--tests`).
+- E2E/CLI tests often shell out; prefer running them explicitly when changing CLI/runtime glue.
+
+## Commands
+- Fast cycle (unit only): `./gradlew test --tests "*unit*"`
+- Integration focus: `./gradlew test --tests "riid.integration.*"`
+- Full suite (if env ready: network, podman/porto): `./gradlew test`
+
+## Conventions
+- Name integration folders by the main modules touched (`runtime_app`, `client_cache`, `config_client`, `dispatcher_runtime`, etc.) for discoverability.
+- Keep unit tests within their module


### PR DESCRIPTION
App: реализован Cli с флагами repo/tag/digest/runtime/auth/TLS
Auth: TTL в конфиге, парсинг WWW-Authenticate на Apache HC5,  stub верификация TLS путей.
Документация: README, помодульно, docker, test в docs/
Тесты: для CLI unit, интеграционный и e2e
улучшение предыдущих: написаны unit для coverage throw/catch в client.services, config validator(с Reason)
4 ADR(decision records)