### PR TITLE
Structured logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Minimal steps to run the client end-to-end from the Shadow JAR.
 ./gradlew clean shadowJar
 ```
 
-The JAR will be at `build/libs/riid.jar` (manifest points to `riid.app.RiidCli`).
+The JAR will be at `build/libs/riid.jar` (manifest points to `riid.app.CliApplication`).
 
 ## Run (E2E smoke)
 Pull BusyBox into Podman runtime using the default config:

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -68,7 +68,8 @@ idea {
 
 tasks.withType<com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar> {
     archiveClassifier.set("")
+    archiveFileName.set("riid.jar")
     manifest {
-        attributes("Main-Class" to "riid.app.RiidCli")
+        attributes("Main-Class" to "riid.app.CliApplication")
     }
 }

--- a/buildSrc/src/main/kotlin/riid.code-quality.gradle.kts
+++ b/buildSrc/src/main/kotlin/riid.code-quality.gradle.kts
@@ -6,6 +6,9 @@ import org.gradle.testing.jacoco.tasks.JacocoReport
 
 val skipQuality = project.hasProperty("skipQuality")
 
+private fun isGeneratedPath(path: String): Boolean =
+    path.replace('\\', '/').contains("/generated/")
+
 extensions.configure(CheckstyleExtension::class) {
     configFile = file("config/checkstyle/checkstyle.xml")
 }
@@ -15,6 +18,9 @@ tasks.withType(Checkstyle::class).configureEach {
     if (name != "checkstyleMain") {
         configFile = file("config/checkstyle/checkstyle-test.xml")
     }
+    source = source.matching {
+        exclude { isGeneratedPath(it.file.absolutePath) }
+    }
 }
 
 tasks.withType(Pmd::class).configureEach {
@@ -22,6 +28,9 @@ tasks.withType(Pmd::class).configureEach {
     if (name != "pmdMain") {
         ruleSetFiles = files("config/pmd/pmd-test.xml")
         ruleSets = emptyList()
+    }
+    source = source.matching {
+        exclude { isGeneratedPath(it.file.absolutePath) }
     }
 }
 

--- a/docs/app.md
+++ b/docs/app.md
@@ -49,6 +49,10 @@ TLS (wired to HTTP client):
 Other:
 - `--help` — show usage
 
+## Logging
+
+Structured **JSON logs** (stdout/stderr) with `trace_id`, step `event`s, and masking: see [logs-policy.md](logs-policy.md). Entry point sets request MDC and emits `request.start` / `request.finish`; `ImageLoadingFacade` and `OciArchiveBuilder` emit manifest/archive/import milestones.
+
 ## Exit codes
 - `0` — success
 - `64` — usage errors (missing/unknown flags, required options not provided)

--- a/docs/app.md
+++ b/docs/app.md
@@ -4,8 +4,7 @@
 CLI and dependency wiring layer for loading container images: parse flags, validate user input, invoke `ImageLoadService`, and return exit codes.
 
 ## Architecture
-- `RiidCli` (JAR entrypoint): minimal `main`, calls CLI, returns exit code only.
-- `CliApplication`: parses args, prints help/usage, validates options (repo/runtime/auth/cert/key/CA), handles exit codes and stdout/stderr.
+- `CliApplication` (JAR `Main-Class`): `main`, parses args, prints help/usage, validates options (repo/runtime/auth/cert/key/CA), exit codes and stdout/stderr.
 - `CliParser` (inside `CliApplication`): pure argument parser → DTO `CliOptions`.
 - `ImageLoadServiceFactory`: reads YAML (`config/config.yaml`), assembles dependencies (RegistryClient, Dispatcher, P2P stub, RuntimeRegistry).
 - `ImageLoadService`: façade that downloads, assembles OCI, and imports into runtime; no CLI logic.

--- a/docs/client.md
+++ b/docs/client.md
@@ -49,3 +49,7 @@ var res = client.fetchBlob(new BlobRequest("library/busybox", layer.digest(), la
   - `SECURITY:TLS:<kind>: <safe_message>`
   - `SECURITY:AUTH:<kind>: <safe_message>`
 
+### Logging
+
+Registry/client log lines participate in the same JSON pipeline as the rest of the CLI: MDC (`trace_id`, `component`, `operation`) and Logstash JSON output. Do not log secrets; encoder masking covers `token` / `password` / `authorization` fields in JSON. See [logs-policy.md](logs-policy.md).
+

--- a/docs/logs-policy.md
+++ b/docs/logs-policy.md
@@ -1,0 +1,65 @@
+# Logs policy (structured JSON)
+
+One **JSON object per line** (NDJSON) on the root logger (console in the fat JAR). Config: `logback.xml` includes `logback-encoder-masking.xml`. Stack: SLF4J 2, Logback, LogstashEncoder.
+## Line format
+Each log line is a single JSON object. Typical fields:
+| Field | Source | Notes |
+|--------|--------|--------|
+| `timestamp` | Encoder | ISO-8601 offset datetime |
+| `level` | Logback | e.g. `INFO`, `WARN`, `ERROR` |
+| `message` | Logger | Human-readable text |
+| `logger_name` | Logback | Java logger name |
+| `thread_name` | Logback | Thread |
+| `trace_id` | MDC | Request correlation; set for the whole CLI request |
+| `component` | MDC | e.g. `app` |
+| `operation` | MDC | Current phase (`request`, `manifest.fetch`, `source.select`, …) |
+| `event` | Key-value | Present on **step / milestone** events |
+| `result` | Key-value | `success` or `error` on step events |
+| `duration_ms` | Key-value | Duration on step events |
+| `error_kind` | Key-value | On failures (see below) |
+| `error_code` | Key-value | On failures; module-local string |
+
+## Fields
+
+These are emitted via `MilestoneEventLogger` (and dispatcher helper) on the success path of a normal pull:
+| `event` | Where | Typical `operation` (MDC) |
+|---------|--------|-----------------------------|
+| `request.start` | `CliApplication` | `request` |
+| `manifest.fetch` | `ImageLoadingFacade` | `manifest.fetch` |
+| `source.select` | `DispatcherMilestoneLogger` | `source.select` |
+| `source.fetch` | `DispatcherMilestoneLogger` | `source.fetch` |
+| `archive.build` | `OciArchiveBuilder` / dispatcher | `archive.build` |
+| `engine.import` | `ImageLoadingFacade` | `engine.import` |
+| `request.finish` | `CliApplication` | `request` |
+**Milestone rows** should include `event`, `result`, and `duration_ms`. Error rows should add `error_kind` and `error_code`.
+
+
+## Step events (`event`)
+
+Typical pull order: `request.start` → `manifest.fetch` → `source.select` → `source.fetch` → `archive.build` → `engine.import` → `request.finish`. Emitters: `CliApplication`, `ImageLoadingFacade`, `DispatcherMilestoneLogger`, `OciArchiveBuilder`. Step rows must have `event`, `result`, `duration_ms`. `error_kind` values in use: `VALIDATION`, `NETWORK`, `RUNTIME`, `INTERNAL`.
+
+## Masking
+
+`MaskingJsonGeneratorDecorator` masks JSON paths `authorization`, `password`, `token`, `identityToken` and applies regex fallbacks (Bearer, `key=value`). Do not log raw secrets in messages—masking is a safety net.
+
+Redaction test config: `src/test/moduled/resources/logback-redaction-test.xml`.
+
+## `jq` examples
+
+Pure NDJSON (e.g. `java -jar … &> riid.ndjson`):
+
+```bash
+jq -c 'select(.event != null)' riid.ndjson
+jq -r 'select(.trace_id != null) | .trace_id' riid.ndjson | sort -u
+jq -c 'select(.event != null) | {t: .timestamp, e: .event, r: .result, ms: .duration_ms}' riid.ndjson
+```
+
+Strip leading non-JSON text before piping to `jq` if your capture includes status lines.
+
+## Modules
+
+**App:** sets MDC; request / manifest / archive / import milestones. **Dispatcher:** `source.select` / `source.fetch`. **Client / P2P / runtime:** avoid secrets and unsafe paths in log text.
+
+## Code & tests
+
+`MilestoneEventLogger`, `MdcContext`, `LogContextKeys`, `DispatcherMilestoneLogger`. Integration: `CliEndToEndLiveTest` (milestones + `trace_id` on non-milestone `riid.*` logs).

--- a/gradle/dependencies.gradle.kts
+++ b/gradle/dependencies.gradle.kts
@@ -11,6 +11,8 @@ dependencies {
     add("testImplementation", platform("org.testcontainers:testcontainers-bom:1.21.4"))//idea say<=1.21 it vulnerable
     add("testImplementation", "org.testcontainers:junit-jupiter")//but this lib only in 1.21 version// TODO: at May check 2.0.3
     add("testImplementation", "org.testcontainers:testcontainers")//this lib has 2.0.3 version
+    add("runtimeOnly", "ch.qos.logback:logback-classic:1.5.32")
+    add("runtimeOnly", "net.logstash.logback:logstash-logback-encoder:9.0")
     add("testRuntimeOnly", "ch.qos.logback:logback-classic:1.5.12")
     add("compileOnly", "com.github.spotbugs:spotbugs-annotations:4.9.8")
     add("testCompileOnly", "com.github.spotbugs:spotbugs-annotations:4.9.8")

--- a/gradle/dependencies.gradle.kts
+++ b/gradle/dependencies.gradle.kts
@@ -1,4 +1,6 @@
 dependencies {
+    add("testFixturesImplementation", "org.slf4j:slf4j-api:2.0.13")
+
     // HTTP/Auth parsing (Apache HttpClient 5 + core)
     add("implementation", "org.apache.httpcomponents.client5:httpclient5:5.3.1")
     add("implementation", "org.apache.httpcomponents.core5:httpcore5:5.2.4")
@@ -6,6 +8,8 @@ dependencies {
     add("implementation", "com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.17.2")
     add("testImplementation", platform("org.junit:junit-bom:5.10.0"))
     add("testImplementation", "org.junit.jupiter:junit-jupiter")
+    add("testImplementation", "ch.qos.logback:logback-classic:1.5.32")
+    add("testImplementation", "net.logstash.logback:logstash-logback-encoder:9.0")
     add("testRuntimeOnly", "org.junit.platform:junit-platform-launcher")
     add("testImplementation", "com.tngtech.archunit:archunit-junit5:1.3.0")
     add("testImplementation", platform("org.testcontainers:testcontainers-bom:1.21.4"))//idea say<=1.21 it vulnerable

--- a/src/main/java/riid/app/CliApplication.java
+++ b/src/main/java/riid/app/CliApplication.java
@@ -127,12 +127,6 @@ public final class CliApplication {
             }
             ImageLoader loader = serviceFactory.create(options);
             loader.load(options.repository(), options.reference(), options.runtimeId());
-            out.printf(
-                    "Loaded %s (%s) into runtime %s%n",
-                    options.repository(),
-                    options.reference(),
-                    options.runtimeId()
-            );
             if (options.hasCerts()) {
                 out.println("Note: cert/key/CA options accepted but not yet used (stub).");
             }

--- a/src/main/java/riid/app/CliApplication.java
+++ b/src/main/java/riid/app/CliApplication.java
@@ -1,41 +1,23 @@
 package riid.app;
 
-import java.io.IOException;
 import java.io.OutputStreamWriter;
 import java.io.PrintWriter;
 import java.nio.charset.StandardCharsets;
-import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 
-import org.apache.commons.cli.CommandLine;
-import org.apache.commons.cli.CommandLineParser;
-import org.apache.commons.cli.DefaultParser;
-import org.apache.commons.cli.MissingArgumentException;
-import org.apache.commons.cli.Option;
-import org.apache.commons.cli.Options;
-import org.apache.commons.cli.ParseException;
-import org.apache.commons.cli.UnrecognizedOptionException;
-
-import riid.core.fs.NioHostFilesystem;
+import riid.app.config.ConfigResolvingLoaderProvider;
 import riid.client.core.config.Credentials;
-import riid.client.core.config.RegistryEndpoint;
-import riid.core.config.ConfigLoader;
-import riid.core.config.GlobalConfig;
-import riid.p2p.P2PExecutor;
 import riid.runtime.RuntimeAdapter;
 
 /**
  * Minimal CLI parser/runner for ImageLoadingFacade.
  */
 public final class CliApplication {
-    private static final String OPTION_CONFIG = "config";
     private static final Path DEFAULT_CONFIG_PATH = Paths.get("config", "config.yaml");
-    private static final RegistryEndpoint DEFAULT_REGISTRY_ENDPOINT =
-            new RegistryEndpoint("https", "registry-1.docker.io", -1, null);
 
     enum ExitCode {
         OK(0),
@@ -71,7 +53,7 @@ public final class CliApplication {
 
     public static CliApplication createDefault() {
         return new CliApplication(
-                CliApplication::defaultServiceFactory,
+                ConfigResolvingLoaderProvider::create,
                 ImageLoadingFacade.defaultRuntimes(),
                 new PrintWriter(new OutputStreamWriter(System.out, StandardCharsets.UTF_8), true),
                 new PrintWriter(new OutputStreamWriter(System.err, StandardCharsets.UTF_8), true)
@@ -125,62 +107,6 @@ public final class CliApplication {
         }
     }
 
-    private static ImageLoader defaultServiceFactory(CliOptions options) throws Exception {
-        if (!options.configProvidedByUser() && !Files.exists(options.configPath())) {
-            RegistryEndpoint endpoint = applyCredentials(DEFAULT_REGISTRY_ENDPOINT, options.credentials());
-            return defaultLoaderWithBuiltInConfig(endpoint);
-        }
-        GlobalConfig config = ConfigLoader.load(options.configPath());
-        RegistryEndpoint endpoint = config.client().registries().getFirst();
-        endpoint = applyCredentials(endpoint, options.credentials());
-        String registry = endpoint.registryName();
-        return (repository, reference, runtimeId) -> {
-            try (ImageLoadingFacade facade = ImageLoadingFacade.createFromConfig(
-                    options.configPath(),
-                    options.credentials()
-            )) {
-                return facade.load(
-                        ImageId.fromRegistry(registry, repository, reference),
-                        runtimeId
-                ).toString();
-            } catch (Exception e) {
-                throw new RuntimeException("Failed to load image", e);
-            }
-        };
-    }
-
-    private static RegistryEndpoint applyCredentials(RegistryEndpoint endpoint, Credentials credentials) {
-        if (credentials == null) {
-            return endpoint;
-        }
-        return new RegistryEndpoint(
-                endpoint.scheme(),
-                endpoint.host(),
-                endpoint.port(),
-                credentials
-        );
-    }
-
-    private static ImageLoader defaultLoaderWithBuiltInConfig(RegistryEndpoint endpoint) {
-        return (repository, reference, runtimeId) -> {
-            var fs = new NioHostFilesystem();
-            try (ImageLoadingFacade facade = ImageLoadingFacade.createDefault(
-                    endpoint,
-                    null,
-                    new P2PExecutor.NoOp(),
-                    ImageLoadingFacade.defaultRuntimes(),
-                    fs
-            )) {
-                return facade.load(
-                        ImageId.fromRegistry(endpoint.registryName(), repository, reference),
-                        runtimeId
-                ).toString();
-            } catch (Exception e) {
-                throw new RuntimeException("Failed to load image", e);
-            }
-        };
-    }
-    
     private void printUsage(PrintWriter writer) {
         String usage = String.join("%n",
                 "Usage: riid --repo <name> [--tag <tag>|--digest <sha256:...>] --runtime <id>",
@@ -223,169 +149,6 @@ public final class CliApplication {
     }
 
     record ParseResult(CliOptions options, boolean showHelp, String errorMessage) {
-    }
-
-    /**
-     * Parses CLI arguments and performs basic validation.
-     */
-    static final class CliParser {
-        private static final String ARG_PATH = "path";
-        private static final int MAX_PASSWORD_SOURCES = 1;
-
-        private CliParser() {
-        }
-
-        static ParseResult parse(String[] args) {
-            if (args == null || args.length == 0) {
-                return new ParseResult(null, false, "No arguments provided");
-            }
-            Options parsedOptions = new Options();
-            parsedOptions.addOption(Option.builder("h")
-                    .longOpt("help")
-                    .desc("Show help")
-                    .build());
-            addOption(parsedOptions, OPTION_CONFIG, ARG_PATH);
-            addOption(parsedOptions, "repo", "name");
-            addOption(parsedOptions, "tag", "tag");
-            addOption(parsedOptions, "ref", "ref");
-            addOption(parsedOptions, "digest", "digest");
-            addOption(parsedOptions, "runtime", "id");
-            addOption(parsedOptions, "username", "user");
-            addOption(parsedOptions, "password", "pwd");
-            addOption(parsedOptions, "password-env", "var");
-            addOption(parsedOptions, "password-file", ARG_PATH);
-            addOption(parsedOptions, "cert-path", ARG_PATH);
-            addOption(parsedOptions, "key-path", ARG_PATH);
-            addOption(parsedOptions, "ca-path", ARG_PATH);
-
-            CommandLine cmd;
-            CommandLineParser parser = new DefaultParser();
-            try {
-                cmd = parser.parse(parsedOptions, args);
-            } catch (UnrecognizedOptionException e) {
-                return new ParseResult(null, false, "Unknown option: " + e.getOption());
-            } catch (MissingArgumentException e) {
-                return new ParseResult(null, false,
-                        "Missing value for " + formatOption(e.getOption()));
-            } catch (ParseException e) {
-                return new ParseResult(null, false, e.getMessage());
-            }
-
-            if (!cmd.getArgList().isEmpty()) {
-                return new ParseResult(null, false, "Unexpected argument: " + cmd.getArgList().getFirst());
-            }
-            if (cmd.hasOption("help")) {
-                return new ParseResult(null, true, null);
-            }
-
-            boolean configProvidedByUser = cmd.hasOption(OPTION_CONFIG);
-            Path configPath = Paths.get(cmd.getOptionValue(OPTION_CONFIG, DEFAULT_CONFIG_PATH.toString()));
-            String repo = cmd.getOptionValue("repo");
-            String tag = cmd.getOptionValue("tag");
-            String ref = cmd.getOptionValue("ref");
-            String digest = cmd.getOptionValue("digest");
-            String runtimeId = cmd.getOptionValue("runtime");
-            String username = cmd.getOptionValue("username");
-            String password = cmd.getOptionValue("password");
-            String passwordEnv = cmd.getOptionValue("password-env");
-            Path passwordFile = cmd.hasOption("password-file")
-                    ? Paths.get(cmd.getOptionValue("password-file"))
-                    : null;
-            Path certPath = cmd.hasOption("cert-path") ? Paths.get(cmd.getOptionValue("cert-path")) : null;
-            Path keyPath = cmd.hasOption("key-path") ? Paths.get(cmd.getOptionValue("key-path")) : null;
-            Path caPath = cmd.hasOption("ca-path") ? Paths.get(cmd.getOptionValue("ca-path")) : null;
-            if (repo == null || repo.isBlank()) {
-                return new ParseResult(null, false, "Repository is required (--repo)");
-            }
-            if (runtimeId == null || runtimeId.isBlank()) {
-                return new ParseResult(null, false, "Runtime id is required (--runtime)");
-            }
-
-            if (countNonNull(password, passwordEnv, passwordFile) > MAX_PASSWORD_SOURCES) {
-                return new ParseResult(null, false, "Use only one of --password, --password-env or --password-file");
-            }
-            String resolvedPassword = password;
-            if (passwordEnv != null) {
-                resolvedPassword = System.getenv(passwordEnv);
-                if (resolvedPassword == null || resolvedPassword.isBlank()) {
-                    return new ParseResult(null, false, "Env var " + passwordEnv + " is not set or empty");
-                }
-            } else if (passwordFile != null) {
-                try {
-                    resolvedPassword = Files.readString(passwordFile).trim();
-                } catch (IOException e) {
-                    return new ParseResult(null, false, "Unable to read password file: " + e.getMessage());
-                }
-                if (resolvedPassword.isBlank()) {
-                    return new ParseResult(null, false, "Password file is empty: " + passwordFile);
-                }
-            }
-            if (username != null && resolvedPassword == null) {
-                return new ParseResult(null, false, "Password is required when username is provided");
-            }
-            if (resolvedPassword != null && username == null) {
-                return new ParseResult(null, false, "Username is required when password is provided");
-            }
-            Credentials credentials = null;
-            if (username != null) {
-                credentials = Credentials.basic(username, resolvedPassword);
-            }
-
-            if (certPath != null && !Files.exists(certPath)) {
-                return new ParseResult(null, false, "cert-path does not exist: " + certPath);
-            }
-            if (keyPath != null && !Files.exists(keyPath)) {
-                return new ParseResult(null, false, "key-path does not exist: " + keyPath);
-            }
-            if (caPath != null && !Files.exists(caPath)) {
-                return new ParseResult(null, false, "ca-path does not exist: " + caPath);
-            }
-            String reference = digest != null
-                    ? digest
-                    : (tag != null ? tag : (ref != null ? ref : "latest"));
-
-            CliOptions cliOptions = new CliOptions(
-                    configPath,
-                    configProvidedByUser,
-                    repo,
-                    reference,
-                    runtimeId,
-                    credentials,
-                    certPath,
-                    keyPath,
-                    caPath
-            );
-            return new ParseResult(cliOptions, false, null);
-        }
-
-        @SafeVarargs
-        private static int countNonNull(Object... items) {
-            int count = 0;
-            for (Object item : items) {
-                if (item != null) {
-                    count++;
-                }
-            }
-            return count;
-        }
-
-        private static void addOption(Options options, String longOpt, String argName) {
-            options.addOption(Option.builder()
-                    .longOpt(longOpt)
-                    .hasArg()
-                    .argName(argName)
-                    .build());
-        }
-
-        private static String formatOption(Option option) {
-            if (option == null) {
-                return "option";
-            }
-            if (option.getLongOpt() != null) {
-                return "--" + option.getLongOpt();
-            }
-            return "-" + option.getOpt();
-        }
     }
 
     @FunctionalInterface

--- a/src/main/java/riid/app/CliApplication.java
+++ b/src/main/java/riid/app/CliApplication.java
@@ -11,6 +11,7 @@ import java.util.Set;
 import java.util.UUID;
 
 import riid.app.config.ConfigResolvingLoaderProvider;
+import riid.app.error.AppException;
 import riid.client.core.config.Credentials;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -143,13 +144,16 @@ public final class CliApplication {
             return ExitCode.OK.code();
         } catch (Exception e) {
             err.println("Failed to load image: " + e.getMessage());
+            String errorCode = e instanceof AppException appException
+                    ? appException.errorCode()
+                    : "REQUEST_EXECUTION_FAILED";
             MilestoneEventLogger.error(LOGGER)
                     .addCause(e)
                     .addEvent("request.finish")
                     .addResult("error")
                     .addDurationFrom(requestStartedNs)
                     .addErrorKind("INTERNAL")
-                    .addErrorCode("REQUEST_EXECUTION_FAILED")
+                    .addErrorCode(errorCode)
                     .log("Request failed");
             return ExitCode.FAILURE.code();
         } finally {

--- a/src/main/java/riid/app/CliApplication.java
+++ b/src/main/java/riid/app/CliApplication.java
@@ -8,15 +8,21 @@ import java.nio.file.Paths;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+import java.util.UUID;
 
 import riid.app.config.ConfigResolvingLoaderProvider;
 import riid.client.core.config.Credentials;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import riid.core.logging.MdcContext;
+import riid.core.logging.MilestoneEventLogger;
 import riid.runtime.RuntimeAdapter;
 
 /**
  * Minimal CLI parser/runner for ImageLoadingFacade.
  */
 public final class CliApplication {
+    private static final Logger LOGGER = LoggerFactory.getLogger(CliApplication.class);
     private static final Path DEFAULT_CONFIG_PATH = Paths.get("config", "config.yaml");
 
     enum ExitCode {
@@ -69,26 +75,55 @@ public final class CliApplication {
     }
 
     public int run(String[] args) {
-        ParseResult result = CliParser.parse(args);
-        if (result.errorMessage != null) {
-            err.println("Error: " + result.errorMessage);
-            printUsage(err);
-            return ExitCode.USAGE.code();
-        }
-        if (result.showHelp) {
-            printUsage(out);
-            return ExitCode.OK.code();
-        }
-        CliOptions options = result.options;
-        if (!availableRuntimes.contains(options.runtimeId())) {
-            err.printf(
-                    "Unknown runtime '%s'. Available: %s%n",
-                    options.runtimeId(),
-                    String.join(", ", availableRuntimes)
-            );
-            return ExitCode.RUNTIME_NOT_FOUND.code();
-        }
+        long requestStartedNs = System.nanoTime();
+        String traceId = UUID.randomUUID().toString();
+        MdcContext.putTraceId(traceId);
+        MdcContext.putComponent("app");
+        MdcContext.putOperation("request");
+        MilestoneEventLogger.info(LOGGER)
+                .addEvent("request.start")
+                .addResult("success")
+                .addDurationMs(0L)
+                .log("Request started");
         try {
+            ParseResult result = CliParser.parse(args);
+            if (result.errorMessage != null) {
+                err.println("Error: " + result.errorMessage);
+                printUsage(err);
+                MilestoneEventLogger.warn(LOGGER)
+                        .addEvent("request.finish")
+                        .addResult("error")
+                        .addDurationFrom(requestStartedNs)
+                        .addErrorKind("VALIDATION")
+                        .addErrorCode("CLI_USAGE_ERROR")
+                        .log("Request failed with usage error");
+                return ExitCode.USAGE.code();
+            }
+            if (result.showHelp) {
+                printUsage(out);
+                MilestoneEventLogger.info(LOGGER)
+                        .addEvent("request.finish")
+                        .addResult("success")
+                        .addDurationFrom(requestStartedNs)
+                        .log("Request finished (help)");
+                return ExitCode.OK.code();
+            }
+            CliOptions options = result.options;
+            if (!availableRuntimes.contains(options.runtimeId())) {
+                err.printf(
+                        "Unknown runtime '%s'. Available: %s%n",
+                        options.runtimeId(),
+                        String.join(", ", availableRuntimes)
+                );
+                MilestoneEventLogger.warn(LOGGER)
+                        .addEvent("request.finish")
+                        .addResult("error")
+                        .addDurationFrom(requestStartedNs)
+                        .addErrorKind("VALIDATION")
+                        .addErrorCode("RUNTIME_NOT_FOUND")
+                        .log("Request failed: unknown runtime");
+                return ExitCode.RUNTIME_NOT_FOUND.code();
+            }
             ImageLoader loader = serviceFactory.create(options);
             loader.load(options.repository(), options.reference(), options.runtimeId());
             out.printf(
@@ -100,10 +135,25 @@ public final class CliApplication {
             if (options.hasCerts()) {
                 out.println("Note: cert/key/CA options accepted but not yet used (stub).");
             }
+            MilestoneEventLogger.info(LOGGER)
+                    .addEvent("request.finish")
+                    .addResult("success")
+                    .addDurationFrom(requestStartedNs)
+                    .log("Request finished");
             return ExitCode.OK.code();
         } catch (Exception e) {
             err.println("Failed to load image: " + e.getMessage());
+            MilestoneEventLogger.error(LOGGER)
+                    .addCause(e)
+                    .addEvent("request.finish")
+                    .addResult("error")
+                    .addDurationFrom(requestStartedNs)
+                    .addErrorKind("INTERNAL")
+                    .addErrorCode("REQUEST_EXECUTION_FAILED")
+                    .log("Request failed");
             return ExitCode.FAILURE.code();
+        } finally {
+            MdcContext.clearRequestContext();
         }
     }
 

--- a/src/main/java/riid/app/CliParser.java
+++ b/src/main/java/riid/app/CliParser.java
@@ -1,0 +1,182 @@
+package riid.app;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import org.apache.commons.cli.CommandLine;
+import org.apache.commons.cli.CommandLineParser;
+import org.apache.commons.cli.DefaultParser;
+import org.apache.commons.cli.MissingArgumentException;
+import org.apache.commons.cli.Option;
+import org.apache.commons.cli.Options;
+import org.apache.commons.cli.ParseException;
+import org.apache.commons.cli.UnrecognizedOptionException;
+
+import riid.client.core.config.Credentials;
+
+/**
+ * Parses CLI arguments and performs basic validation.
+ */
+final class CliParser {
+    private static final String OPTION_CONFIG = "config";
+    private static final Path DEFAULT_CONFIG_PATH = Paths.get("config", "config.yaml");
+    private static final String ARG_PATH = "path";
+    private static final int MAX_PASSWORD_SOURCES = 1;
+
+    private CliParser() {
+    }
+
+    static CliApplication.ParseResult parse(String[] args) {
+        if (args == null || args.length == 0) {
+            return new CliApplication.ParseResult(null, false, "No arguments provided");
+        }
+        Options parsedOptions = new Options();
+        parsedOptions.addOption(Option.builder("h")
+                .longOpt("help")
+                .desc("Show help")
+                .build());
+        addOption(parsedOptions, OPTION_CONFIG, ARG_PATH);
+        addOption(parsedOptions, "repo", "name");
+        addOption(parsedOptions, "tag", "tag");
+        addOption(parsedOptions, "ref", "ref");
+        addOption(parsedOptions, "digest", "digest");
+        addOption(parsedOptions, "runtime", "id");
+        addOption(parsedOptions, "username", "user");
+        addOption(parsedOptions, "password", "pwd");
+        addOption(parsedOptions, "password-env", "var");
+        addOption(parsedOptions, "password-file", ARG_PATH);
+        addOption(parsedOptions, "cert-path", ARG_PATH);
+        addOption(parsedOptions, "key-path", ARG_PATH);
+        addOption(parsedOptions, "ca-path", ARG_PATH);
+
+        CommandLine cmd;
+        CommandLineParser parser = new DefaultParser();
+        try {
+            cmd = parser.parse(parsedOptions, args);
+        } catch (UnrecognizedOptionException e) {
+            return new CliApplication.ParseResult(null, false, "Unknown option: " + e.getOption());
+        } catch (MissingArgumentException e) {
+            return new CliApplication.ParseResult(null, false,
+                    "Missing value for " + formatOption(e.getOption()));
+        } catch (ParseException e) {
+            return new CliApplication.ParseResult(null, false, e.getMessage());
+        }
+
+        if (!cmd.getArgList().isEmpty()) {
+            return new CliApplication.ParseResult(null, false, "Unexpected argument: " + cmd.getArgList().getFirst());
+        }
+        if (cmd.hasOption("help")) {
+            return new CliApplication.ParseResult(null, true, null);
+        }
+
+        boolean configProvidedByUser = cmd.hasOption(OPTION_CONFIG);
+        Path configPath = Paths.get(cmd.getOptionValue(OPTION_CONFIG, DEFAULT_CONFIG_PATH.toString()));
+        String repo = cmd.getOptionValue("repo");
+        String tag = cmd.getOptionValue("tag");
+        String ref = cmd.getOptionValue("ref");
+        String digest = cmd.getOptionValue("digest");
+        String runtimeId = cmd.getOptionValue("runtime");
+        String username = cmd.getOptionValue("username");
+        String password = cmd.getOptionValue("password");
+        String passwordEnv = cmd.getOptionValue("password-env");
+        Path passwordFile = cmd.hasOption("password-file")
+                ? Paths.get(cmd.getOptionValue("password-file"))
+                : null;
+        Path certPath = cmd.hasOption("cert-path") ? Paths.get(cmd.getOptionValue("cert-path")) : null;
+        Path keyPath = cmd.hasOption("key-path") ? Paths.get(cmd.getOptionValue("key-path")) : null;
+        Path caPath = cmd.hasOption("ca-path") ? Paths.get(cmd.getOptionValue("ca-path")) : null;
+        if (repo == null || repo.isBlank()) {
+            return new CliApplication.ParseResult(null, false, "Repository is required (--repo)");
+        }
+        if (runtimeId == null || runtimeId.isBlank()) {
+            return new CliApplication.ParseResult(null, false, "Runtime id is required (--runtime)");
+        }
+
+        if (countNonNull(password, passwordEnv, passwordFile) > MAX_PASSWORD_SOURCES) {
+            return new CliApplication.ParseResult(null, false, "Use only one of --password, --password-env or --password-file");
+        }
+        String resolvedPassword = password;
+        if (passwordEnv != null) {
+            resolvedPassword = System.getenv(passwordEnv);
+            if (resolvedPassword == null || resolvedPassword.isBlank()) {
+                return new CliApplication.ParseResult(null, false, "Env var " + passwordEnv + " is not set or empty");
+            }
+        } else if (passwordFile != null) {
+            try {
+                resolvedPassword = Files.readString(passwordFile).trim();
+            } catch (IOException e) {
+                return new CliApplication.ParseResult(null, false, "Unable to read password file: " + e.getMessage());
+            }
+            if (resolvedPassword.isBlank()) {
+                return new CliApplication.ParseResult(null, false, "Password file is empty: " + passwordFile);
+            }
+        }
+        if (username != null && resolvedPassword == null) {
+            return new CliApplication.ParseResult(null, false, "Password is required when username is provided");
+        }
+        if (resolvedPassword != null && username == null) {
+            return new CliApplication.ParseResult(null, false, "Username is required when password is provided");
+        }
+        Credentials credentials = null;
+        if (username != null) {
+            credentials = Credentials.basic(username, resolvedPassword);
+        }
+
+        if (certPath != null && !Files.exists(certPath)) {
+            return new CliApplication.ParseResult(null, false, "cert-path does not exist: " + certPath);
+        }
+        if (keyPath != null && !Files.exists(keyPath)) {
+            return new CliApplication.ParseResult(null, false, "key-path does not exist: " + keyPath);
+        }
+        if (caPath != null && !Files.exists(caPath)) {
+            return new CliApplication.ParseResult(null, false, "ca-path does not exist: " + caPath);
+        }
+        String reference = digest != null
+                ? digest
+                : (tag != null ? tag : (ref != null ? ref : "latest"));
+
+        CliApplication.CliOptions cliOptions = new CliApplication.CliOptions(
+                configPath,
+                configProvidedByUser,
+                repo,
+                reference,
+                runtimeId,
+                credentials,
+                certPath,
+                keyPath,
+                caPath
+        );
+        return new CliApplication.ParseResult(cliOptions, false, null);
+    }
+
+    @SafeVarargs
+    private static int countNonNull(Object... items) {
+        int count = 0;
+        for (Object item : items) {
+            if (item != null) {
+                count++;
+            }
+        }
+        return count;
+    }
+
+    private static void addOption(Options options, String longOpt, String argName) {
+        options.addOption(Option.builder()
+                .longOpt(longOpt)
+                .hasArg()
+                .argName(argName)
+                .build());
+    }
+
+    private static String formatOption(Option option) {
+        if (option == null) {
+            return "option";
+        }
+        if (option.getLongOpt() != null) {
+            return "--" + option.getLongOpt();
+        }
+        return "-" + option.getOpt();
+    }
+}

--- a/src/main/java/riid/app/ImageLoadingFacade.java
+++ b/src/main/java/riid/app/ImageLoadingFacade.java
@@ -32,6 +32,8 @@ import riid.core.config.ConfigLoader;
 import riid.core.config.GlobalConfig;
 import riid.dispatcher.RequestDispatcher;
 import riid.dispatcher.SimpleRequestDispatcher;
+import riid.core.logging.MdcContext;
+import riid.core.logging.MilestoneEventLogger;
 import riid.p2p.DragonflyGrpcP2PExecutor;
 import riid.p2p.P2PExecutor;
 import riid.runtime.BoundedCommandExecution;
@@ -96,7 +98,30 @@ public final class ImageLoadingFacade implements AutoCloseable {
     public ImageId load(ImageId imageId, String runtimeId) {
         Objects.requireNonNull(imageId, "imageId");
         ensureRegistryAllowed(imageId.registry());
-        ManifestResult manifestResult = client.fetchManifest(imageId.name(), imageId.reference());
+        String previousOperation = MdcContext.getOperation();
+        MdcContext.putOperation("manifest.fetch");
+        long manifestStartedNs = System.nanoTime();
+        ManifestResult manifestResult;
+        try {
+            manifestResult = client.fetchManifest(imageId.name(), imageId.reference());
+            MilestoneEventLogger.info(LOGGER)
+                    .addEvent("manifest.fetch")
+                    .addResult("success")
+                    .addDurationMs(durationMs(manifestStartedNs))
+                    .log("Manifest fetched");
+        } catch (Exception e) {
+            MilestoneEventLogger.error(LOGGER)
+                    .addCause(e)
+                    .addEvent("manifest.fetch")
+                    .addResult("error")
+                    .addDurationMs(durationMs(manifestStartedNs))
+                    .addErrorKind("NETWORK")
+                    .addErrorCode("MANIFEST_FETCH_FAILED")
+                    .log("Manifest fetch failed");
+            throw e;
+        } finally {
+            MdcContext.restoreOperation(previousOperation);
+        }
         RuntimeAdapter runtime = runtimeRegistry.get(runtimeId);
         ImageId resolved = imageId.withDigest(manifestResult.digest());
         return load(manifestResult, runtime, resolved);
@@ -111,27 +136,59 @@ public final class ImageLoadingFacade implements AutoCloseable {
         Objects.requireNonNull(manifestResult, "manifestResult");
         Objects.requireNonNull(runtime, "runtime");
         Objects.requireNonNull(imageId, "imageId");
+        String previousOperation = MdcContext.getOperation();
+        MdcContext.putOperation("engine.import");
+        long engineStartedNs = System.nanoTime();
         try {
             return archiveBuilder.withArchive(imageId, manifestResult, archivePath -> {
                 runtime.importImage(archivePath);
-                LOGGER.info("Loaded {} into runtime {} at {}", imageId, runtime.runtimeId(), archivePath);
+                MilestoneEventLogger.info(LOGGER)
+                        .addEvent("engine.import")
+                        .addResult("success")
+                        .addDurationMs(durationMs(engineStartedNs))
+                        .log("Loaded " + imageId + " into runtime " + runtime.runtimeId() + " at " + archivePath);
                 return imageId;
             });
         } catch (AppException e) {
-            LOGGER.error("App error while loading {} into runtime {}: {}",
-                    imageId, runtime.runtimeId(), e.getMessage(), e);
+            MilestoneEventLogger.error(LOGGER)
+                    .addCause(e)
+                    .addEvent("engine.import")
+                    .addResult("error")
+                    .addDurationMs(durationMs(engineStartedNs))
+                    .addErrorKind("RUNTIME")
+                    .addErrorCode("APP_RUNTIME_ERROR")
+                    .log("App error while loading " + imageId + " into runtime " + runtime.runtimeId()
+                            + ": " + e.getMessage());
             throw e;
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
             String msg = AppError.RuntimeErrorKind.LOAD_FAILED.format(runtime.runtimeId());
+            MilestoneEventLogger.error(LOGGER)
+                    .addCause(e)
+                    .addEvent("engine.import")
+                    .addResult("error")
+                    .addDurationMs(durationMs(engineStartedNs))
+                    .addErrorKind("RUNTIME")
+                    .addErrorCode("ENGINE_IMPORT_INTERRUPTED")
+                    .log("Runtime import interrupted");
             throw new AppException(
                     new AppError.RuntimeError(AppError.RuntimeErrorKind.LOAD_FAILED, msg),
                     msg, e);
         } catch (IOException e) {
             String msg = AppError.RuntimeErrorKind.LOAD_FAILED.format(runtime.runtimeId());
+            MilestoneEventLogger.error(LOGGER)
+                    .addCause(e)
+                    .addEvent("engine.import")
+                    .addResult("error")
+                    .addDurationMs(durationMs(engineStartedNs))
+                    .addErrorKind("RUNTIME")
+                    .addErrorCode("ENGINE_IMPORT_IO_ERROR")
+                    .log("Runtime import I/O error");
             throw new AppException(
                     new AppError.RuntimeError(AppError.RuntimeErrorKind.LOAD_FAILED, msg),
                     msg, e);
+        } finally {
+            MdcContext.restoreOperation(previousOperation);
         }
     }
 
@@ -268,6 +325,11 @@ public final class ImageLoadingFacade implements AutoCloseable {
     public interface CacheCleaner {
         void close() throws Exception;
     }
+
+    private static long durationMs(long startedNs) {
+        return (System.nanoTime() - startedNs) / 1_000_000L;
+    }
+
 }
 
 

--- a/src/main/java/riid/app/ImageLoadingFacade.java
+++ b/src/main/java/riid/app/ImageLoadingFacade.java
@@ -156,36 +156,38 @@ public final class ImageLoadingFacade implements AutoCloseable {
                     .addResult("error")
                     .addDurationMs(durationMs(engineStartedNs))
                     .addErrorKind("RUNTIME")
-                    .addErrorCode("APP_RUNTIME_ERROR")
+                    .addErrorCode(e.errorCode())
                     .log("App error while loading " + imageId + " into runtime " + runtime.runtimeId()
                             + ": " + e.getMessage());
             throw e;
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
-            String msg = AppError.RuntimeErrorKind.LOAD_FAILED.format(runtime.runtimeId());
+            AppError.RuntimeErrorKind errorKind = AppError.RuntimeErrorKind.LOAD_FAILED;
+            String msg = errorKind.format(runtime.runtimeId());
             MilestoneEventLogger.error(LOGGER)
                     .addCause(e)
                     .addEvent("engine.import")
                     .addResult("error")
                     .addDurationMs(durationMs(engineStartedNs))
                     .addErrorKind("RUNTIME")
-                    .addErrorCode("ENGINE_IMPORT_INTERRUPTED")
+                    .addErrorCode(errorKind.name())
                     .log("Runtime import interrupted");
             throw new AppException(
-                    new AppError.RuntimeError(AppError.RuntimeErrorKind.LOAD_FAILED, msg),
+                    new AppError.RuntimeError(errorKind, msg),
                     msg, e);
         } catch (IOException e) {
-            String msg = AppError.RuntimeErrorKind.LOAD_FAILED.format(runtime.runtimeId());
+            AppError.RuntimeErrorKind errorKind = AppError.RuntimeErrorKind.LOAD_FAILED;
+            String msg = errorKind.format(runtime.runtimeId());
             MilestoneEventLogger.error(LOGGER)
                     .addCause(e)
                     .addEvent("engine.import")
                     .addResult("error")
                     .addDurationMs(durationMs(engineStartedNs))
                     .addErrorKind("RUNTIME")
-                    .addErrorCode("ENGINE_IMPORT_IO_ERROR")
+                    .addErrorCode(errorKind.name())
                     .log("Runtime import I/O error");
             throw new AppException(
-                    new AppError.RuntimeError(AppError.RuntimeErrorKind.LOAD_FAILED, msg),
+                    new AppError.RuntimeError(errorKind, msg),
                     msg, e);
         } finally {
             MdcContext.restoreOperation(previousOperation);

--- a/src/main/java/riid/app/ImageLoadingFacade.java
+++ b/src/main/java/riid/app/ImageLoadingFacade.java
@@ -12,6 +12,7 @@ import java.util.Set;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import riid.app.config.AppConfig;
 import riid.app.error.AppError;
 import riid.app.error.AppException;
 import riid.core.fs.HostFilesystem;

--- a/src/main/java/riid/app/config/AppConfig.java
+++ b/src/main/java/riid/app/config/AppConfig.java
@@ -1,4 +1,4 @@
-package riid.app;
+package riid.app.config;
 
 import java.nio.file.Path;
 import java.util.List;

--- a/src/main/java/riid/app/config/ConfigResolvingLoaderProvider.java
+++ b/src/main/java/riid/app/config/ConfigResolvingLoaderProvider.java
@@ -1,0 +1,79 @@
+package riid.app.config;
+
+import java.nio.file.Files;
+
+import riid.app.CliApplication;
+import riid.app.ImageId;
+import riid.app.ImageLoadingFacade;
+import riid.client.core.config.RegistryEndpoint;
+import riid.core.config.ConfigLoader;
+import riid.core.config.GlobalConfig;
+import riid.core.fs.NioHostFilesystem;
+import riid.p2p.P2PExecutor;
+
+/**
+ * Resolves config source (file vs built-in defaults) and produces an image loader.
+ */
+public final class ConfigResolvingLoaderProvider {
+    private static final RegistryEndpoint DEFAULT_REGISTRY_ENDPOINT =
+            new RegistryEndpoint("https", "registry-1.docker.io", -1, null);
+
+    private ConfigResolvingLoaderProvider() {
+    }
+
+    static CliApplication.ImageLoader create(CliApplication.CliOptions options) throws Exception {
+        if (!options.configProvidedByUser() && !Files.exists(options.configPath())) {
+            RegistryEndpoint endpoint = options.credentials() == null
+                    ? DEFAULT_REGISTRY_ENDPOINT
+                    : new RegistryEndpoint(
+                            DEFAULT_REGISTRY_ENDPOINT.scheme(),
+                            DEFAULT_REGISTRY_ENDPOINT.host(),
+                            DEFAULT_REGISTRY_ENDPOINT.port(),
+                            options.credentials());
+            return defaultLoaderWithBuiltInConfig(endpoint);
+        }
+        GlobalConfig config = ConfigLoader.load(options.configPath());
+        RegistryEndpoint endpoint = config.client().registries().getFirst();
+        if (options.credentials() != null) {
+            endpoint = new RegistryEndpoint(
+                    endpoint.scheme(),
+                    endpoint.host(),
+                    endpoint.port(),
+                    options.credentials());
+        }
+        String registry = endpoint.registryName();
+        return (repository, reference, runtimeId) -> {
+            try (ImageLoadingFacade facade = ImageLoadingFacade.createFromConfig(
+                    options.configPath(),
+                    options.credentials()
+            )) {
+                return facade.load(
+                        ImageId.fromRegistry(registry, repository, reference),
+                        runtimeId
+                ).toString();
+            } catch (Exception e) {
+                throw new RuntimeException("Failed to load image", e);
+            }
+        };
+    }
+
+    private static CliApplication.ImageLoader defaultLoaderWithBuiltInConfig(RegistryEndpoint endpoint) {
+        return (repository, reference, runtimeId) -> {
+            var fs = new NioHostFilesystem();
+            try (ImageLoadingFacade facade = ImageLoadingFacade.createDefault(
+                    endpoint,
+                    null,
+                    new P2PExecutor.NoOp(),
+                    ImageLoadingFacade.defaultRuntimes(),
+                    fs
+            )) {
+                return facade.load(
+                        ImageId.fromRegistry(endpoint.registryName(), repository, reference),
+                        runtimeId
+                ).toString();
+            } catch (Exception e) {
+                throw new RuntimeException("Failed to load image", e);
+            }
+        };
+    }
+}

--- a/src/main/java/riid/app/config/ConfigResolvingLoaderProvider.java
+++ b/src/main/java/riid/app/config/ConfigResolvingLoaderProvider.java
@@ -21,7 +21,7 @@ public final class ConfigResolvingLoaderProvider {
     private ConfigResolvingLoaderProvider() {
     }
 
-    static CliApplication.ImageLoader create(CliApplication.CliOptions options) throws Exception {
+    public static CliApplication.ImageLoader create(CliApplication.CliOptions options) throws Exception {
         if (!options.configProvidedByUser() && !Files.exists(options.configPath())) {
             RegistryEndpoint endpoint = options.credentials() == null
                     ? DEFAULT_REGISTRY_ENDPOINT

--- a/src/main/java/riid/app/error/AppException.java
+++ b/src/main/java/riid/app/error/AppException.java
@@ -23,5 +23,15 @@ public class AppException extends RuntimeException {
     public AppError error() {
         return appError;
     }
+
+    public String errorCode() {
+        if (appError instanceof AppError.RuntimeError runtimeError) {
+            return runtimeError.kind().name();
+        }
+        if (appError instanceof AppError.OciError ociError) {
+            return ociError.kind().name();
+        }
+        return "APP_ERROR";
+    }
 }
 

--- a/src/main/java/riid/app/ociarchive/OciArchiveBuilder.java
+++ b/src/main/java/riid/app/ociarchive/OciArchiveBuilder.java
@@ -18,13 +18,18 @@ import riid.core.fs.PathSupport;
 import riid.client.api.ManifestResult;
 import riid.core.model.manifest.Manifest;
 import riid.core.model.manifest.MediaType;
+import riid.core.logging.MdcContext;
+import riid.core.logging.MilestoneEventLogger;
 import riid.dispatcher.RequestDispatcher;
 import riid.dispatcher.model.RepositoryName;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Builds an OCI archive from a manifest, pulling blobs via RequestDispatcher.
  */
 public final class OciArchiveBuilder {
+    private static final Logger LOGGER = LoggerFactory.getLogger(OciArchiveBuilder.class);
     private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
 
     private final RequestDispatcher dispatcher;
@@ -44,8 +49,28 @@ public final class OciArchiveBuilder {
     public <T> T withArchive(ImageId imageId,
                              ManifestResult manifestResult,
                              ArchiveUser<T> user) throws IOException, InterruptedException {
+        String previousOperation = MdcContext.getOperation();
+        MdcContext.putOperation("archive.build");
+        long startedNs = System.nanoTime();
         try (OciArchive archive = build(imageId, manifestResult)) {
+            MilestoneEventLogger.info(LOGGER)
+                    .addEvent("archive.build")
+                    .addResult("success")
+                    .addDurationMs(durationMs(startedNs))
+                    .log("OCI archive build completed");
             return user.use(archive.archivePath());
+        } catch (IOException | InterruptedException | RuntimeException e) {
+            MilestoneEventLogger.error(LOGGER)
+                    .addCause(e)
+                    .addEvent("archive.build")
+                    .addResult("error")
+                    .addDurationMs(durationMs(startedNs))
+                    .addErrorKind("INTERNAL")
+                    .addErrorCode("ARCHIVE_BUILD_FAILED")
+                    .log("OCI archive build failed");
+            throw e;
+        } finally {
+            MdcContext.restoreOperation(previousOperation);
         }
     }
 
@@ -139,6 +164,10 @@ public final class OciArchiveBuilder {
                     new AppError.OciError(AppError.OciErrorKind.RESOURCE_READ_FAILED, msg),
                     msg, e);
         }
+    }
+
+    private static long durationMs(long startedNs) {
+        return (System.nanoTime() - startedNs) / 1_000_000L;
     }
 }
 

--- a/src/main/java/riid/core/config/ConfigValidator.java
+++ b/src/main/java/riid/core/config/ConfigValidator.java
@@ -6,7 +6,7 @@ import java.time.Duration;
 import java.util.List;
 import java.util.Objects;
 
-import riid.app.AppConfig;
+import riid.app.config.AppConfig;
 import riid.client.core.config.AuthConfig;
 import riid.client.core.config.ClientConfig;
 import riid.client.core.config.RegistryEndpoint;

--- a/src/main/java/riid/core/config/ConfigValidator.java
+++ b/src/main/java/riid/core/config/ConfigValidator.java
@@ -11,7 +11,7 @@ import riid.client.core.config.AuthConfig;
 import riid.client.core.config.ClientConfig;
 import riid.client.core.config.RegistryEndpoint;
 import riid.client.http.HttpClientConfig;
-import riid.dispatcher.DispatcherConfig;
+import riid.dispatcher.core.config.DispatcherConfig;
 import riid.p2p.DragonflyConfig;
 import riid.p2p.P2PConfig;
 import riid.runtime.OutputConfig;

--- a/src/main/java/riid/core/config/GlobalConfig.java
+++ b/src/main/java/riid/core/config/GlobalConfig.java
@@ -3,7 +3,7 @@ package riid.core.config;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import riid.app.config.AppConfig;
 import riid.client.core.config.ClientConfig;
-import riid.dispatcher.DispatcherConfig;
+import riid.dispatcher.core.config.DispatcherConfig;
 import riid.runtime.RuntimeConfig;
 import riid.p2p.P2PConfig;
 

--- a/src/main/java/riid/core/config/GlobalConfig.java
+++ b/src/main/java/riid/core/config/GlobalConfig.java
@@ -1,7 +1,7 @@
 package riid.core.config;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import riid.app.AppConfig;
+import riid.app.config.AppConfig;
 import riid.client.core.config.ClientConfig;
 import riid.dispatcher.DispatcherConfig;
 import riid.runtime.RuntimeConfig;

--- a/src/main/java/riid/core/logging/LogContextKeys.java
+++ b/src/main/java/riid/core/logging/LogContextKeys.java
@@ -1,0 +1,19 @@
+package riid.core.logging;
+
+/**
+ * Shared structured logging keys.
+ */
+public final class LogContextKeys {
+    public static final String TRACE_ID = "trace_id";
+    public static final String COMPONENT = "component";
+    public static final String OPERATION = "operation";
+
+    public static final String EVENT = "event";
+    public static final String RESULT = "result";
+    public static final String DURATION_MS = "duration_ms";
+    public static final String ERROR_KIND = "error_kind";
+    public static final String ERROR_CODE = "error_code";
+
+    private LogContextKeys() {
+    }
+}

--- a/src/main/java/riid/core/logging/MdcContext.java
+++ b/src/main/java/riid/core/logging/MdcContext.java
@@ -1,0 +1,45 @@
+package riid.core.logging;
+
+import org.slf4j.MDC;
+
+/**
+ * Thin wrapper over MDC operations with shared keys.
+ */
+public final class MdcContext {
+    private MdcContext() {
+    }
+
+    public static void putTraceId(String traceId) {
+        MDC.put(LogContextKeys.TRACE_ID, traceId);
+    }
+
+    public static void putComponent(String component) {
+        MDC.put(LogContextKeys.COMPONENT, component);
+    }
+
+    public static void putOperation(String operation) {
+        MDC.put(LogContextKeys.OPERATION, operation);
+    }
+
+    public static String getOperation() {
+        return MDC.get(LogContextKeys.OPERATION);
+    }
+
+    public static void restoreOperation(String previousOperation) {
+        if (previousOperation == null || previousOperation.isBlank()) {
+            MDC.remove(LogContextKeys.OPERATION);
+            return;
+        }
+        MDC.put(LogContextKeys.OPERATION, previousOperation);
+    }
+
+    public static void clearOperation() {
+        MDC.remove(LogContextKeys.OPERATION);
+    }
+
+    public static void clearRequestContext() {
+        MDC.remove(LogContextKeys.OPERATION);
+        MDC.remove(LogContextKeys.COMPONENT);
+        MDC.remove(LogContextKeys.TRACE_ID);
+    }
+}

--- a/src/main/java/riid/core/logging/MilestoneEventLogger.java
+++ b/src/main/java/riid/core/logging/MilestoneEventLogger.java
@@ -1,0 +1,72 @@
+package riid.core.logging;
+
+import java.util.Objects;
+
+import org.slf4j.Logger;
+import org.slf4j.spi.LoggingEventBuilder;
+
+/**
+ * Thin wrapper over SLF4J fluent API for structured step events.
+ */
+public final class MilestoneEventLogger {
+    private MilestoneEventLogger() {
+    }
+
+    public static Event info(Logger logger) {
+        return new Event(Objects.requireNonNull(logger, "logger").atInfo());
+    }
+
+    public static Event warn(Logger logger) {
+        return new Event(Objects.requireNonNull(logger, "logger").atWarn());
+    }
+
+    public static Event error(Logger logger) {
+        return new Event(Objects.requireNonNull(logger, "logger").atError());
+    }
+
+    public static final class Event {
+        private final LoggingEventBuilder builder;
+
+        private Event(LoggingEventBuilder builder) {
+            this.builder = Objects.requireNonNull(builder, "builder");
+        }
+
+        public Event addEvent(String event) {
+            Objects.requireNonNull(builder.addKeyValue(LogContextKeys.EVENT, event), "builder");
+            return this;
+        }
+
+        public Event addResult(String result) {
+            Objects.requireNonNull(builder.addKeyValue(LogContextKeys.RESULT, result), "builder");
+            return this;
+        }
+
+        public Event addDurationMs(long durationMs) {
+            Objects.requireNonNull(builder.addKeyValue(LogContextKeys.DURATION_MS, durationMs), "builder");
+            return this;
+        }
+
+        public Event addDurationFrom(long startedNs) {
+            return addDurationMs((System.nanoTime() - startedNs) / 1_000_000L);
+        }
+
+        public Event addErrorKind(String errorKind) {
+            Objects.requireNonNull(builder.addKeyValue(LogContextKeys.ERROR_KIND, errorKind), "builder");
+            return this;
+        }
+
+        public Event addErrorCode(String errorCode) {
+            Objects.requireNonNull(builder.addKeyValue(LogContextKeys.ERROR_CODE, errorCode), "builder");
+            return this;
+        }
+
+        public Event addCause(Throwable cause) {
+            Objects.requireNonNull(builder.setCause(cause), "builder");
+            return this;
+        }
+
+        public void log(String message) {
+            builder.log(message);
+        }
+    }
+}

--- a/src/main/java/riid/dispatcher/SimpleRequestDispatcher.java
+++ b/src/main/java/riid/dispatcher/SimpleRequestDispatcher.java
@@ -24,6 +24,8 @@ import riid.client.api.BlobResult;
 import riid.client.api.ManifestResult;
 import riid.client.api.RegistryClient;
 import riid.core.model.manifest.MediaType;
+import riid.dispatcher.core.config.DispatcherConfig;
+import riid.dispatcher.core.logging.DispatcherMilestoneLogger;
 import riid.dispatcher.model.FetchResult;
 import riid.dispatcher.model.ImageRef;
 import riid.dispatcher.model.RepositoryName;
@@ -41,6 +43,7 @@ public class SimpleRequestDispatcher implements RequestDispatcher {
     private final P2PExecutor p2p;
     private final HostFilesystem fs;
     private final Optional<Semaphore> registryLimiter; // limits concurrent downloads from registry
+    private final DispatcherMilestoneLogger stepLogger;
 
     public SimpleRequestDispatcher(RegistryClient client,
                                    CacheAdapter cache,
@@ -60,6 +63,7 @@ public class SimpleRequestDispatcher implements RequestDispatcher {
         this.fs = Objects.requireNonNull(fs, "fs");
         int maxConc = config != null ? config.maxConcurrentRegistry() : 0;
         this.registryLimiter = maxConc > 0 ? Optional.of(new Semaphore(maxConc)) : Optional.empty();
+        this.stepLogger = new DispatcherMilestoneLogger(LOGGER);
     }
 
     @Override
@@ -77,6 +81,7 @@ public class SimpleRequestDispatcher implements RequestDispatcher {
     public FetchResult fetchLayer(RepositoryName repository, ImageDigest digest, long sizeBytes, MediaType mediaType) {
         Objects.requireNonNull(repository, "repository");
         Objects.requireNonNull(digest);
+        long selectStartedNs = System.nanoTime();
 
         // 1) cache
         Path cachedPath = null;
@@ -86,12 +91,16 @@ public class SimpleRequestDispatcher implements RequestDispatcher {
                     .orElse(null);
         }
         if (cachedPath != null) {
+            stepLogger.sourceSelectFromCache(selectStartedNs);
+            long fetchStartedNs = System.nanoTime();
             LOGGER.info("cache hit for layer {}", digest);
+            stepLogger.sourceFetchFromCache(fetchStartedNs);
             return new FetchResult(digest, mediaType, cachedPath);
         }
 
         // 2) P2P
         if (p2p != null) {
+            long fetchStartedNs = System.nanoTime();
             try {
                 var p2pPath = p2p.fetch(
                         repository.value(),
@@ -124,6 +133,8 @@ public class SimpleRequestDispatcher implements RequestDispatcher {
                             LOGGER.warn("Failed to put P2P layer {} to cache: {}", digest, ex.getMessage());
                         }
                     }
+                    stepLogger.sourceSelectFromP2p(selectStartedNs);
+                    stepLogger.sourceFetchFromP2p(fetchStartedNs);
                     return new FetchResult(digest, mediaType, resultPath);
                 }
             } catch (IOException ex) {
@@ -132,6 +143,9 @@ public class SimpleRequestDispatcher implements RequestDispatcher {
         }
 
         // 3) Registry download
+        stepLogger.sourceSelectFromRegistry(selectStartedNs);
+        long fetchStartedNs = System.nanoTime();
+        boolean fetchSucceeded = false;
         acquireRegistry();
         try {
             File tmp = createTemp();
@@ -186,10 +200,20 @@ public class SimpleRequestDispatcher implements RequestDispatcher {
                 }
             }
 
+            fetchSucceeded = true;
             return new FetchResult(ImageDigest.parse(blob.digest()),
                     MediaType.from(blob.mediaType()),
                     resultPath);
+        } catch (RuntimeException e) {
+            stepLogger.sourceFetchFailed(fetchStartedNs, e);
+            throw e;
+        } catch (Error e) {
+            stepLogger.sourceFetchFailed(fetchStartedNs, e);
+            throw e;
         } finally {
+            if (fetchSucceeded) {
+                stepLogger.sourceFetchFromRegistry(fetchStartedNs);
+            }
             releaseRegistry();
         }
     }

--- a/src/main/java/riid/dispatcher/core/config/DispatcherConfig.java
+++ b/src/main/java/riid/dispatcher/core/config/DispatcherConfig.java
@@ -1,4 +1,4 @@
-package riid.dispatcher;
+package riid.dispatcher.core.config;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 

--- a/src/main/java/riid/dispatcher/core/logging/DispatcherMilestoneLogger.java
+++ b/src/main/java/riid/dispatcher/core/logging/DispatcherMilestoneLogger.java
@@ -1,0 +1,89 @@
+package riid.dispatcher.core.logging;
+
+import java.util.Objects;
+
+import org.slf4j.Logger;
+
+import riid.core.logging.MdcContext;
+import riid.core.logging.MilestoneEventLogger;
+
+public final class DispatcherMilestoneLogger {
+    private final Logger logger;
+
+    public DispatcherMilestoneLogger(Logger logger) {
+        this.logger = Objects.requireNonNull(logger, "logger");
+    }
+
+    public void sourceSelectFromCache(long startedNs) {
+        withOperation("source.select", () -> MilestoneEventLogger.info(logger)
+                .addEvent("source.select")
+                .addResult("success")
+                .addDurationMs(durationMs(startedNs))
+                .log("Source selected: cache"));
+    }
+
+    public void sourceSelectFromP2p(long startedNs) {
+        withOperation("source.select", () -> MilestoneEventLogger.info(logger)
+                .addEvent("source.select")
+                .addResult("success")
+                .addDurationMs(durationMs(startedNs))
+                .log("Source selected: p2p"));
+    }
+
+    public void sourceSelectFromRegistry(long startedNs) {
+        withOperation("source.select", () -> MilestoneEventLogger.info(logger)
+                .addEvent("source.select")
+                .addResult("success")
+                .addDurationMs(durationMs(startedNs))
+                .log("Source selected: registry"));
+    }
+
+    public void sourceFetchFromCache(long startedNs) {
+        withOperation("source.fetch", () -> MilestoneEventLogger.info(logger)
+                .addEvent("source.fetch")
+                .addResult("success")
+                .addDurationMs(durationMs(startedNs))
+                .log("Source fetched: cache"));
+    }
+
+    public void sourceFetchFromP2p(long startedNs) {
+        withOperation("source.fetch", () -> MilestoneEventLogger.info(logger)
+                .addEvent("source.fetch")
+                .addResult("success")
+                .addDurationMs(durationMs(startedNs))
+                .log("Source fetched: p2p"));
+    }
+
+    public void sourceFetchFromRegistry(long startedNs) {
+        withOperation("source.fetch", () -> MilestoneEventLogger.info(logger)
+                .addEvent("source.fetch")
+                .addResult("success")
+                .addDurationMs(durationMs(startedNs))
+                .log("Source fetched: registry"));
+    }
+
+    public void sourceFetchFailed(long startedNs, Throwable cause) {
+        withOperation("source.fetch", () -> MilestoneEventLogger.error(logger)
+                .addCause(cause)
+                .addEvent("source.fetch")
+                .addResult("error")
+                .addDurationMs(durationMs(startedNs))
+                .addErrorKind("INTERNAL")
+                .addErrorCode("SOURCE_FETCH_FAILED")
+                .log("Source fetch failed"));
+    }
+
+    private static long durationMs(long startedNs) {
+        return (System.nanoTime() - startedNs) / 1_000_000L;
+    }
+
+    private static void withOperation(String operation, Runnable runnable) {
+        String previous = MdcContext.getOperation();
+        MdcContext.putOperation(operation);
+        try {
+            runnable.run();
+        } finally {
+            MdcContext.restoreOperation(previous);
+        }
+    }
+}

--- a/src/main/resources/logback-encoder-masking.xml
+++ b/src/main/resources/logback-encoder-masking.xml
@@ -1,47 +1,34 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!--
-  Shared LogstashEncoder + masking (single source of truth).
-  Included from logback.xml (ConsoleAppender). logback-redaction-test.xml mirrors this encoder inline
-  (FileAppender does not support child &lt;include&gt;).
--->
 <included>
-    <encoder class="net.logstash.logback.encoder.LogstashEncoder">
-        <fieldNames>
-            <timestamp>timestamp</timestamp>
-            <version>[ignore]</version>
-        </fieldNames>
-
-        <!-- Masking policy: path-first, value regex as fallback -->
-        <decorator class="net.logstash.logback.mask.MaskingJsonGeneratorDecorator">
-            <defaultMask>[REDACTED]</defaultMask>
-
-            <!-- Path-based masking (primary) -->
-            <path>authorization</path>
-            <path>password</path>
-            <path>token</path>
-            <path>identityToken</path>
-
-            <!-- Value-based masking (minimal fallback for string payloads) -->
-            <valueMask>
-                <value>(?i)(bearer\\s+)[-A-Za-z0-9._~+/]+=*</value>
-                <mask>$1[REDACTED]</mask>
-            </valueMask>
-            <valueMask>
-                <value>(?i)(authorization|password|token|identityToken)=([^\\s&amp;]+)</value>
-                <mask>$1=[REDACTED]</mask>
-            </valueMask>
-        </decorator>
-
-        <!-- MVP: always propagate correlation context from MDC -->
-        <includeMdcKeyName>trace_id</includeMdcKeyName>
-        <includeMdcKeyName>component</includeMdcKeyName>
-        <includeMdcKeyName>operation</includeMdcKeyName>
-
-        <!-- Keep step-level fields when passed via SLF4J key-values -->
-        <includeKeyValueKeyName>event</includeKeyValueKeyName>
-        <includeKeyValueKeyName>result</includeKeyValueKeyName>
-        <includeKeyValueKeyName>duration_ms</includeKeyValueKeyName>
-        <includeKeyValueKeyName>error_kind</includeKeyValueKeyName>
-        <includeKeyValueKeyName>error_code</includeKeyValueKeyName>
-    </encoder>
+    <appender name="STDOUT_JSON" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder class="net.logstash.logback.encoder.LogstashEncoder">
+            <fieldNames>
+                <timestamp>timestamp</timestamp>
+                <version>[ignore]</version>
+            </fieldNames>
+            <decorator class="net.logstash.logback.mask.MaskingJsonGeneratorDecorator">
+                <defaultMask>[REDACTED]</defaultMask>
+                <path>authorization</path>
+                <path>password</path>
+                <path>token</path>
+                <path>identityToken</path>
+                <valueMask>
+                    <value>(?i)(bearer\\s+)[-A-Za-z0-9._~+/]+=*</value>
+                    <mask>$1[REDACTED]</mask>
+                </valueMask>
+                <valueMask>
+                    <value>(?i)(authorization|password|token|identityToken)=([^\\s&amp;]+)</value>
+                    <mask>$1=[REDACTED]</mask>
+                </valueMask>
+            </decorator>
+            <includeMdcKeyName>trace_id</includeMdcKeyName>
+            <includeMdcKeyName>component</includeMdcKeyName>
+            <includeMdcKeyName>operation</includeMdcKeyName>
+            <includeKeyValueKeyName>event</includeKeyValueKeyName>
+            <includeKeyValueKeyName>result</includeKeyValueKeyName>
+            <includeKeyValueKeyName>duration_ms</includeKeyValueKeyName>
+            <includeKeyValueKeyName>error_kind</includeKeyValueKeyName>
+            <includeKeyValueKeyName>error_code</includeKeyValueKeyName>
+        </encoder>
+    </appender>
 </included>

--- a/src/main/resources/logback-encoder-masking.xml
+++ b/src/main/resources/logback-encoder-masking.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Shared LogstashEncoder + masking (single source of truth).
+  Included from logback.xml (ConsoleAppender). logback-redaction-test.xml mirrors this encoder inline
+  (FileAppender does not support child &lt;include&gt;).
+-->
+<included>
+    <encoder class="net.logstash.logback.encoder.LogstashEncoder">
+        <fieldNames>
+            <timestamp>timestamp</timestamp>
+            <version>[ignore]</version>
+        </fieldNames>
+
+        <!-- Masking policy: path-first, value regex as fallback -->
+        <decorator class="net.logstash.logback.mask.MaskingJsonGeneratorDecorator">
+            <defaultMask>[REDACTED]</defaultMask>
+
+            <!-- Path-based masking (primary) -->
+            <path>authorization</path>
+            <path>password</path>
+            <path>token</path>
+            <path>identityToken</path>
+
+            <!-- Value-based masking (minimal fallback for string payloads) -->
+            <valueMask>
+                <value>(?i)(bearer\\s+)[-A-Za-z0-9._~+/]+=*</value>
+                <mask>$1[REDACTED]</mask>
+            </valueMask>
+            <valueMask>
+                <value>(?i)(authorization|password|token|identityToken)=([^\\s&amp;]+)</value>
+                <mask>$1=[REDACTED]</mask>
+            </valueMask>
+        </decorator>
+
+        <!-- MVP: always propagate correlation context from MDC -->
+        <includeMdcKeyName>trace_id</includeMdcKeyName>
+        <includeMdcKeyName>component</includeMdcKeyName>
+        <includeMdcKeyName>operation</includeMdcKeyName>
+
+        <!-- Keep step-level fields when passed via SLF4J key-values -->
+        <includeKeyValueKeyName>event</includeKeyValueKeyName>
+        <includeKeyValueKeyName>result</includeKeyValueKeyName>
+        <includeKeyValueKeyName>duration_ms</includeKeyValueKeyName>
+        <includeKeyValueKeyName>error_kind</includeKeyValueKeyName>
+        <includeKeyValueKeyName>error_code</includeKeyValueKeyName>
+    </encoder>
+</included>

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -1,45 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <configuration>
     <appender name="STDOUT_JSON" class="ch.qos.logback.core.ConsoleAppender">
-        <encoder class="net.logstash.logback.encoder.LogstashEncoder">
-            <fieldNames>
-                <timestamp>timestamp</timestamp>
-                <version>[ignore]</version>
-            </fieldNames>
-
-            <!-- Masking policy: path-first, value regex as fallback -->
-            <decorator class="net.logstash.logback.mask.MaskingJsonGeneratorDecorator">
-                <defaultMask>[REDACTED]</defaultMask>
-
-                <!-- Path-based masking (primary) -->
-                <path>authorization</path>
-                <path>password</path>
-                <path>token</path>
-                <path>identityToken</path>
-
-                <!-- Value-based masking (minimal fallback for string payloads) -->
-                <valueMask>
-                    <value>(?i)(bearer\\s+)[A-Za-z0-9._~+\\-/]+=*</value>
-                    <mask>$1[REDACTED]</mask>
-                </valueMask>
-                <valueMask>
-                    <value>(?i)(authorization|password|token|identityToken)=([^\\s&amp;]+)</value>
-                    <mask>$1=[REDACTED]</mask>
-                </valueMask>
-            </decorator>
-
-            <!-- MVP: always propagate correlation context from MDC -->
-            <includeMdcKeyName>trace_id</includeMdcKeyName>
-            <includeMdcKeyName>component</includeMdcKeyName>
-            <includeMdcKeyName>operation</includeMdcKeyName>
-
-            <!-- Keep step-level fields when passed via SLF4J key-values -->
-            <includeKeyValueKeyName>event</includeKeyValueKeyName>
-            <includeKeyValueKeyName>result</includeKeyValueKeyName>
-            <includeKeyValueKeyName>duration_ms</includeKeyValueKeyName>
-            <includeKeyValueKeyName>error_kind</includeKeyValueKeyName>
-            <includeKeyValueKeyName>error_code</includeKeyValueKeyName>
-        </encoder>
+        <include resource="logback-encoder-masking.xml"/>
     </appender>
 
     <root level="INFO">

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -7,6 +7,27 @@
                 <version>[ignore]</version>
             </fieldNames>
 
+            <!-- Masking policy: path-first, value regex as fallback -->
+            <decorator class="net.logstash.logback.mask.MaskingJsonGeneratorDecorator">
+                <defaultMask>[REDACTED]</defaultMask>
+
+                <!-- Path-based masking (primary) -->
+                <path>authorization</path>
+                <path>password</path>
+                <path>token</path>
+                <path>identityToken</path>
+
+                <!-- Value-based masking (minimal fallback for string payloads) -->
+                <valueMask>
+                    <value>(?i)(bearer\\s+)[A-Za-z0-9._~+\\-/]+=*</value>
+                    <mask>$1[REDACTED]</mask>
+                </valueMask>
+                <valueMask>
+                    <value>(?i)(authorization|password|token|identityToken)=([^\\s&amp;]+)</value>
+                    <mask>$1=[REDACTED]</mask>
+                </valueMask>
+            </decorator>
+
             <!-- MVP: always propagate correlation context from MDC -->
             <includeMdcKeyName>trace_id</includeMdcKeyName>
             <includeMdcKeyName>component</includeMdcKeyName>

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+    <appender name="STDOUT_JSON" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder class="net.logstash.logback.encoder.LogstashEncoder">
+            <fieldNames>
+                <timestamp>timestamp</timestamp>
+                <version>[ignore]</version>
+            </fieldNames>
+
+            <!-- MVP: always propagate correlation context from MDC -->
+            <includeMdcKeyName>trace_id</includeMdcKeyName>
+            <includeMdcKeyName>component</includeMdcKeyName>
+            <includeMdcKeyName>operation</includeMdcKeyName>
+
+            <!-- Keep step-level fields when passed via SLF4J key-values -->
+            <includeKeyValueKeyName>event</includeKeyValueKeyName>
+            <includeKeyValueKeyName>result</includeKeyValueKeyName>
+            <includeKeyValueKeyName>duration_ms</includeKeyValueKeyName>
+            <includeKeyValueKeyName>error_kind</includeKeyValueKeyName>
+            <includeKeyValueKeyName>error_code</includeKeyValueKeyName>
+        </encoder>
+    </appender>
+
+    <root level="INFO">
+        <appender-ref ref="STDOUT_JSON"/>
+    </root>
+</configuration>

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -1,9 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <configuration>
-    <appender name="STDOUT_JSON" class="ch.qos.logback.core.ConsoleAppender">
-        <include resource="logback-encoder-masking.xml"/>
-    </appender>
-
+    <include resource="logback-encoder-masking.xml"/>
     <root level="INFO">
         <appender-ref ref="STDOUT_JSON"/>
     </root>

--- a/src/test/integration/java/riid/integration/CliEndToEndLiveTest.java
+++ b/src/test/integration/java/riid/integration/CliEndToEndLiveTest.java
@@ -20,6 +20,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.OutputStreamWriter;
 import java.io.PrintWriter;
+import java.lang.ReflectiveOperationException;
 import java.nio.file.Path;
 import java.util.HashSet;
 import java.util.List;
@@ -28,6 +29,7 @@ import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
@@ -95,36 +97,77 @@ class CliEndToEndLiveTest {
             assertTrue(runtime.archiveSize > 0, "archive must be non-empty");
             assertTrue(runtime.lastArchive != null, "archive path should be recorded");
 
-            List<Object> stepEvents = logs.events().stream()
-                    .filter(event -> TestRootLoggerEvents.keyValue(event, "event") != null)
-                    .toList();
+            String traceId = assertMilestoneStepLogging(logs);
+            assertNonMilestoneRiidTraceMatches(logs, traceId);
+        }
+    }
 
-            Set<String> seenEvents = new HashSet<>();
-            Set<String> traceIds = new HashSet<>();
-            for (Object event : stepEvents) {
-                String eventName = TestRootLoggerEvents.keyValue(event, "event");
-                if (eventName == null) {
-                    continue;
-                }
-                seenEvents.add(eventName);
-                String result = TestRootLoggerEvents.keyValue(event, "result");
-                assertNotNull(result, "result must be present for event=" + eventName);
-                String duration = TestRootLoggerEvents.keyValue(event, "duration_ms");
-                assertNotNull(duration, "duration_ms must be present for event=" + eventName);
-                Map<String, String> mdc = TestRootLoggerEvents.mdcPropertyMap(event);
-                String traceId = mdc.get("trace_id");
-                assertNotNull(traceId, "trace_id must be present for event=" + eventName);
-                traceIds.add(traceId);
-            }
+    private static String assertMilestoneStepLogging(TestRootLoggerEvents logs)
+            throws ReflectiveOperationException {
+        List<Object> stepEvents = logs.events().stream()
+                .filter(event -> TestRootLoggerEvents.keyValue(event, "event") != null)
+                .toList();
 
-            assertTrue(seenEvents.contains("request.start"));
-            assertTrue(seenEvents.contains("manifest.fetch"));
-            assertTrue(seenEvents.contains("source.select"));
-            assertTrue(seenEvents.contains("source.fetch"));
-            assertTrue(seenEvents.contains("archive.build"));
-            assertTrue(seenEvents.contains("engine.import"));
-            assertTrue(seenEvents.contains("request.finish"));
-            assertEquals(1, traceIds.size(), "all key step events must share one trace_id");
+        Set<String> seenEvents = new HashSet<>();
+        Set<String> traceIds = new HashSet<>();
+        for (Object event : stepEvents) {
+            String eventName = TestRootLoggerEvents.keyValue(event, "event");
+            seenEvents.add(eventName);
+            String result = TestRootLoggerEvents.keyValue(event, "result");
+            assertNotNull(result, "result must be present for event=" + eventName);
+            String duration = TestRootLoggerEvents.keyValue(event, "duration_ms");
+            assertNotNull(duration, "duration_ms must be present for event=" + eventName);
+            Map<String, String> mdc = TestRootLoggerEvents.mdcPropertyMap(event);
+            String id = mdc.get("trace_id");
+            assertNotNull(id, "trace_id must be present for event=" + eventName);
+            traceIds.add(id);
+        }
+
+        assertTrue(seenEvents.contains("request.start"));
+        assertTrue(seenEvents.contains("manifest.fetch"));
+        assertTrue(seenEvents.contains("source.select"));
+        assertTrue(seenEvents.contains("source.fetch"));
+        assertTrue(seenEvents.contains("archive.build"));
+        assertTrue(seenEvents.contains("engine.import"));
+        assertTrue(seenEvents.contains("request.finish"));
+        assertEquals(1, traceIds.size(), "all key step events must share one trace_id");
+        return traceIds.iterator().next();
+    }
+
+    private static void assertNonMilestoneRiidTraceMatches(TestRootLoggerEvents logs, String expectedTraceId)
+            throws ReflectiveOperationException {
+        List<Object> nonMilestoneRiid = logs.events().stream()
+                .filter(event -> TestRootLoggerEvents.keyValue(event, "event") == null)
+                .filter(CliEndToEndLiveTest::isRiidLogger)
+                .toList();
+        assertFalse(nonMilestoneRiid.isEmpty(), "expected at least one non-milestone log from riid.*");
+        for (Object event : nonMilestoneRiid) {
+            Map<String, String> mdc = TestRootLoggerEvents.mdcPropertyMap(event);
+            assertNotNull(mdc, "MDC map expected for non-milestone riid log");
+            String traceId = mdc.get("trace_id");
+            assertNotNull(traceId,
+                    "trace_id must be present on non-milestone riid logs (logger="
+                            + loggerNameSafe(event) + ")");
+            assertEquals(expectedTraceId, traceId,
+                    "non-milestone log must use same trace_id as milestones (logger="
+                            + loggerNameSafe(event) + ")");
+        }
+    }
+
+    private static boolean isRiidLogger(Object event) {
+        try {
+            String name = TestRootLoggerEvents.loggerName(event);
+            return name != null && name.startsWith("riid.");
+        } catch (ReflectiveOperationException e) {
+            throw new AssertionError(e);
+        }
+    }
+
+    private static String loggerNameSafe(Object event) {
+        try {
+            return TestRootLoggerEvents.loggerName(event);
+        } catch (ReflectiveOperationException e) {
+            return "?";
         }
     }
 

--- a/src/test/integration/java/riid/integration/CliEndToEndLiveTest.java
+++ b/src/test/integration/java/riid/integration/CliEndToEndLiveTest.java
@@ -12,16 +12,23 @@ import riid.cache.oci.TempFileCacheAdapter;
 import riid.client.core.config.RegistryEndpoint;
 import riid.core.config.ConfigLoader;
 import riid.core.config.TestConfigYaml;
+import riid.logging.TestRootLoggerEvents;
 import riid.p2p.P2PExecutor;
 import riid.runtime.RuntimeAdapter;
 
 import java.io.ByteArrayOutputStream;
+import java.io.IOException;
 import java.io.OutputStreamWriter;
 import java.io.PrintWriter;
 import java.nio.file.Path;
+import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
@@ -36,56 +43,89 @@ class CliEndToEndLiveTest {
 
     @Test
     void cliDownloadsAndInvokesRuntimeStub() throws Exception {
-        HostFilesystem fs = new NioHostFilesystem();
-        Path config = TestPaths.tempFile(fs, TestPaths.DEFAULT_BASE_DIR, "config-", ".yaml");
-        fs.writeString(config, TestConfigYaml.minimalDockerHubConfigWithEmptyAuth(2));
+        try (TestRootLoggerEvents logs = TestRootLoggerEvents.attach("cli-e2e")) {
+            HostFilesystem fs = new NioHostFilesystem();
+            Path config = TestPaths.tempFile(fs, TestPaths.DEFAULT_BASE_DIR, "config-", ".yaml");
+            fs.writeString(config, TestConfigYaml.minimalDockerHubConfigWithEmptyAuth(2));
 
-        RecordingRuntimeAdapter runtime = new RecordingRuntimeAdapter(fs);
-        ByteArrayOutputStream outBuf = new ByteArrayOutputStream();
-        ByteArrayOutputStream errBuf = new ByteArrayOutputStream();
+            RecordingRuntimeAdapter runtime = new RecordingRuntimeAdapter(fs);
+            ByteArrayOutputStream outBuf = new ByteArrayOutputStream();
+            ByteArrayOutputStream errBuf = new ByteArrayOutputStream();
 
-        CliApplication cli = new CliApplication(
-                opts -> {
-                    var cfg = ConfigLoader.load(opts.configPath());
-                    RegistryEndpoint endpoint = cfg.client().registries().getFirst();
-                    return (repo, ref, runtimeId) -> {
-                        try (TempFileCacheAdapter cache = new TempFileCacheAdapter(fs);
-                             ImageLoadingFacade svc = ImageLoadingFacade.createDefault(
-                            endpoint,
-                                     cache,
-                            new P2PExecutor.NoOp(),
-                            Map.of(runtime.runtimeId(), runtime),
-                                     fs
-                             )) {
-                            String registry = endpoint.registryName();
-                            return svc.load(
-                            ImageId.fromRegistry(registry, repo, ref),
-                            runtimeId
-                            ).toString();
-                        } catch (Exception e) {
-                            throw new RuntimeException("Failed to load image", e);
-                        }
-                    };
-                },
-                Map.of(runtime.runtimeId(), runtime),
-                new PrintWriter(new OutputStreamWriter(outBuf, java.nio.charset.StandardCharsets.UTF_8), true),
-                new PrintWriter(new OutputStreamWriter(errBuf, java.nio.charset.StandardCharsets.UTF_8), true)
-        );
+            CliApplication cli = new CliApplication(
+                    opts -> {
+                        var cfg = ConfigLoader.load(opts.configPath());
+                        RegistryEndpoint endpoint = cfg.client().registries().getFirst();
+                        return (repo, ref, runtimeId) -> {
+                            try (TempFileCacheAdapter cache = new TempFileCacheAdapter(fs);
+                                 ImageLoadingFacade svc = ImageLoadingFacade.createDefault(
+                                         endpoint,
+                                         cache,
+                                         new P2PExecutor.NoOp(),
+                                         Map.of(runtime.runtimeId(), runtime),
+                                         fs
+                                 )) {
+                                String registry = endpoint.registryName();
+                                return svc.load(
+                                        ImageId.fromRegistry(registry, repo, ref),
+                                        runtimeId
+                                ).toString();
+                            } catch (IOException e) {
+                                throw new RuntimeException("Failed to load image", e);
+                            }
+                        };
+                    },
+                    Map.of(runtime.runtimeId(), runtime),
+                    new PrintWriter(new OutputStreamWriter(outBuf, java.nio.charset.StandardCharsets.UTF_8), true),
+                    new PrintWriter(new OutputStreamWriter(errBuf, java.nio.charset.StandardCharsets.UTF_8), true)
+            );
 
-        int code = cli.run(new String[]{
-                "--config", config.toString(),
-                "--repo", "library/busybox",
-                "--tag", "latest",
-                "--runtime", runtime.runtimeId()
-        });
+            int code = cli.run(new String[]{
+                    "--config", config.toString(),
+                    "--repo", "library/busybox",
+                    "--tag", "latest",
+                    "--runtime", runtime.runtimeId()
+            });
 
-        if (code != 0) {
-            fail("CLI exit code " + code + "\nSTDOUT:\n" + outBuf + "\nSTDERR:\n" + errBuf);
+            if (code != 0) {
+                fail("CLI exit code " + code + "\nSTDOUT:\n" + outBuf + "\nSTDERR:\n" + errBuf);
+            }
+            assertTrue(runtime.called.get(), "runtime should be invoked");
+            assertTrue(runtime.archiveExisted.get(), "archive must exist during import");
+            assertTrue(runtime.archiveSize > 0, "archive must be non-empty");
+            assertTrue(runtime.lastArchive != null, "archive path should be recorded");
+
+            List<Object> stepEvents = logs.events().stream()
+                    .filter(event -> TestRootLoggerEvents.keyValue(event, "event") != null)
+                    .toList();
+
+            Set<String> seenEvents = new HashSet<>();
+            Set<String> traceIds = new HashSet<>();
+            for (Object event : stepEvents) {
+                String eventName = TestRootLoggerEvents.keyValue(event, "event");
+                if (eventName == null) {
+                    continue;
+                }
+                seenEvents.add(eventName);
+                String result = TestRootLoggerEvents.keyValue(event, "result");
+                assertNotNull(result, "result must be present for event=" + eventName);
+                String duration = TestRootLoggerEvents.keyValue(event, "duration_ms");
+                assertNotNull(duration, "duration_ms must be present for event=" + eventName);
+                Map<String, String> mdc = TestRootLoggerEvents.mdcPropertyMap(event);
+                String traceId = mdc.get("trace_id");
+                assertNotNull(traceId, "trace_id must be present for event=" + eventName);
+                traceIds.add(traceId);
+            }
+
+            assertTrue(seenEvents.contains("request.start"));
+            assertTrue(seenEvents.contains("manifest.fetch"));
+            assertTrue(seenEvents.contains("source.select"));
+            assertTrue(seenEvents.contains("source.fetch"));
+            assertTrue(seenEvents.contains("archive.build"));
+            assertTrue(seenEvents.contains("engine.import"));
+            assertTrue(seenEvents.contains("request.finish"));
+            assertEquals(1, traceIds.size(), "all key step events must share one trace_id");
         }
-        assertTrue(runtime.called.get(), "runtime should be invoked");
-        assertTrue(runtime.archiveExisted.get(), "archive must exist during import");
-        assertTrue(runtime.archiveSize > 0, "archive must be non-empty");
-        assertTrue(runtime.lastArchive != null, "archive path should be recorded");
     }
 
     private static final class RecordingRuntimeAdapter implements RuntimeAdapter {
@@ -111,10 +151,9 @@ class CliEndToEndLiveTest {
             this.archiveExisted.set(fs.exists(archive));
             try {
                 this.archiveSize = fs.size(archive);
-            } catch (Exception ignored) {
+            } catch (IOException ignored) {
                 this.archiveSize = 0L;
             }
         }
     }
 }
-

--- a/src/test/integration/java/riid/integration/dispatcher_cache/SimpleRequestDispatcherTest.java
+++ b/src/test/integration/java/riid/integration/dispatcher_cache/SimpleRequestDispatcherTest.java
@@ -29,7 +29,7 @@ import riid.client.api.RegistryClient;
 import riid.core.model.manifest.Descriptor;
 import riid.core.model.manifest.Manifest;
 import riid.core.model.manifest.TagList;
-import riid.dispatcher.DispatcherConfig;
+import riid.dispatcher.core.config.DispatcherConfig;
 import riid.dispatcher.SimpleRequestDispatcher;
 import riid.dispatcher.model.FetchResult;
 import riid.dispatcher.model.ImageRef;

--- a/src/test/integration/resources/logback-test.xml
+++ b/src/test/integration/resources/logback-test.xml
@@ -2,7 +2,7 @@
 <configuration>
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
-            <pattern>%d{HH:mm:ss.SSS} %-5level %logger{36} - %msg%n</pattern>
+            <pattern>%d{HH:mm:ss.SSS} %-5level %logger{50} - %msg%n</pattern>
         </encoder>
     </appender>
 

--- a/src/test/moduled/java/riid/app/CliApplicationTest.java
+++ b/src/test/moduled/java/riid/app/CliApplicationTest.java
@@ -145,29 +145,6 @@ class CliApplicationTest {
     }
 
     @Test
-    void parserMarksConfigAsImplicitByDefault() {
-        var result = CliParser.parse(new String[]{
-                "--repo", REPO_BUSYBOX,
-                "--runtime", RUNTIME_PODMAN
-        });
-
-        assertEquals(false, result.options().configProvidedByUser());
-        assertEquals(Path.of("config", "config.yaml"), result.options().configPath());
-    }
-
-    @Test
-    void parserMarksConfigAsExplicitWhenProvided() {
-        var result = CliParser.parse(new String[]{
-                "--config", "custom.yaml",
-                "--repo", REPO_BUSYBOX,
-                "--runtime", RUNTIME_PODMAN
-        });
-
-        assertEquals(true, result.options().configProvidedByUser());
-        assertEquals(Path.of("custom.yaml"), result.options().configPath());
-    }
-
-    @Test
     void digestOverridesTag() {
         AtomicReference<String> refSeen = new AtomicReference<>();
         CliApplication app = new CliApplication(

--- a/src/test/moduled/java/riid/app/CliApplicationTest.java
+++ b/src/test/moduled/java/riid/app/CliApplicationTest.java
@@ -146,7 +146,7 @@ class CliApplicationTest {
 
     @Test
     void parserMarksConfigAsImplicitByDefault() {
-        var result = CliApplication.CliParser.parse(new String[]{
+        var result = CliParser.parse(new String[]{
                 "--repo", REPO_BUSYBOX,
                 "--runtime", RUNTIME_PODMAN
         });
@@ -157,7 +157,7 @@ class CliApplicationTest {
 
     @Test
     void parserMarksConfigAsExplicitWhenProvided() {
-        var result = CliApplication.CliParser.parse(new String[]{
+        var result = CliParser.parse(new String[]{
                 "--config", "custom.yaml",
                 "--repo", REPO_BUSYBOX,
                 "--runtime", RUNTIME_PODMAN

--- a/src/test/moduled/java/riid/app/CliParserTest.java
+++ b/src/test/moduled/java/riid/app/CliParserTest.java
@@ -1,0 +1,34 @@
+package riid.app;
+
+import java.nio.file.Path;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import org.junit.jupiter.api.Test;
+
+class CliParserTest {
+    private static final String RUNTIME_PODMAN = "podman";
+    private static final String REPO_BUSYBOX = "library/busybox";
+
+    @Test
+    void parserMarksConfigAsImplicitByDefault() {
+        var result = CliParser.parse(new String[]{
+                "--repo", REPO_BUSYBOX,
+                "--runtime", RUNTIME_PODMAN
+        });
+
+        assertEquals(false, result.options().configProvidedByUser());
+        assertEquals(Path.of("config", "config.yaml"), result.options().configPath());
+    }
+
+    @Test
+    void parserMarksConfigAsExplicitWhenProvided() {
+        var result = CliParser.parse(new String[]{
+                "--config", "custom.yaml",
+                "--repo", REPO_BUSYBOX,
+                "--runtime", RUNTIME_PODMAN
+        });
+
+        assertEquals(true, result.options().configProvidedByUser());
+        assertEquals(Path.of("custom.yaml"), result.options().configPath());
+    }
+}

--- a/src/test/moduled/java/riid/config/ConfigBranchTest.java
+++ b/src/test/moduled/java/riid/config/ConfigBranchTest.java
@@ -7,7 +7,7 @@ import riid.client.core.config.AuthConfig;
 import riid.client.core.config.ClientConfig;
 import riid.client.core.config.RegistryEndpoint;
 import riid.client.http.HttpClientConfig;
-import riid.dispatcher.DispatcherConfig;
+import riid.dispatcher.core.config.DispatcherConfig;
 
 import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;

--- a/src/test/moduled/java/riid/core/logging/LogRedactionTest.java
+++ b/src/test/moduled/java/riid/core/logging/LogRedactionTest.java
@@ -1,0 +1,86 @@
+package riid.core.logging;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.LoggerContext;
+import ch.qos.logback.classic.joran.JoranConfigurator;
+import ch.qos.logback.classic.util.LogbackMDCAdapter;
+
+/**
+ * 7.4 Redaction: secrets must not appear raw in log lines; masking yields [REDACTED].
+ */
+@SuppressWarnings("PMD.AvoidDuplicateLiterals")
+class LogRedactionTest {
+
+    private static final String SECRET_PASSWORD = "p4ssw0rd_unit_test_leak";
+    private static final String SECRET_TOKEN = "tok_unit_test_leak_abc";
+    private static final String SECRET_BEARER = "Bearer unit_test_bearer_leak";
+
+    private static final String BEARER_REGEX = "(?i)(bearer\\s+)[-A-Za-z0-9._~+/]+=*";
+    private static final String BEARER_MASK = "$1[REDACTED]";
+    private static final String KV_REGEX = "(?i)(authorization|password|token|identityToken)=([^\\s&]+)";
+    private static final String KV_MASK = "$1=[REDACTED]";
+
+    @Test
+    void structuredLogJsonDoesNotContainRawSecrets() throws Exception {
+        Path logFile = Files.createTempFile("redaction-log", ".ndjson");
+        logFile.toFile().deleteOnExit();
+
+        LoggerContext context = new LoggerContext();
+        context.setMDCAdapter(new LogbackMDCAdapter());
+        context.putProperty("redaction.log.path", logFile.toAbsolutePath().toString().replace('\\', '/'));
+
+        JoranConfigurator configurator = new JoranConfigurator();
+        configurator.setContext(context);
+        try (InputStream cfg = LogRedactionTest.class.getResourceAsStream("/logback-redaction-test.xml")) {
+            if (cfg == null) {
+                throw new IllegalStateException("Missing classpath resource logback-redaction-test.xml");
+            }
+            configurator.doConfigure(cfg);
+        }
+        context.start();
+        try {
+            Logger logger = context.getLogger("redaction-test");
+            logger.atInfo()
+                    .addKeyValue("password", SECRET_PASSWORD)
+                    .addKeyValue("token", SECRET_TOKEN)
+                    .addKeyValue("authorization", SECRET_BEARER)
+                    .log("synthetic milestone");
+        } finally {
+            context.stop();
+        }
+
+        String line = new String(Files.readAllBytes(logFile), StandardCharsets.UTF_8).trim();
+        assertFalse(line.isEmpty(), line);
+        assertFalse(line.contains(SECRET_PASSWORD), line);
+        assertFalse(line.contains(SECRET_TOKEN), line);
+        assertFalse(line.contains("unit_test_bearer_leak"), line);
+        assertTrue(line.contains("[REDACTED]"), line);
+    }
+
+    @Test
+    void exceptionStyleMessagesDoNotLeakSecretsAfterValueMasking() throws IOException {
+        String raw = "failed: password=" + SECRET_PASSWORD
+                + " token=" + SECRET_TOKEN
+                + " " + SECRET_BEARER;
+        String masked = applyValueMasks(raw);
+        assertFalse(masked.contains(SECRET_PASSWORD));
+        assertFalse(masked.contains(SECRET_TOKEN));
+        assertFalse(masked.contains("unit_test_bearer_leak"));
+    }
+
+    private static String applyValueMasks(String input) {
+        String step1 = input.replaceAll(BEARER_REGEX, BEARER_MASK);
+        return step1.replaceAll(KV_REGEX, KV_MASK);
+    }
+}

--- a/src/test/moduled/java/riid/core/logging/LogbackMaskingRulesTest.java
+++ b/src/test/moduled/java/riid/core/logging/LogbackMaskingRulesTest.java
@@ -1,0 +1,50 @@
+package riid.core.logging;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+@SuppressWarnings("PMD.AvoidDuplicateLiterals")
+class LogbackMaskingRulesTest {
+    private static final String BEARER_REGEX = "(?i)(bearer\\s+)[-A-Za-z0-9._~+/]+=*";
+    private static final String BEARER_MASK = "$1[REDACTED]";
+    private static final String KV_REGEX = "(?i)(authorization|password|token|identityToken)=([^\\s&]+)";
+    private static final String KV_MASK = "$1=[REDACTED]";
+
+    @Test
+    void logbackConfigContainsMaskingDecoratorAndPaths() throws IOException {
+        String root = Files.readString(Path.of("src", "main", "resources", "logback.xml"));
+        assertTrue(root.contains("include resource=\"logback-encoder-masking.xml\""),
+                "logback.xml must include shared encoder/masking fragment");
+
+        String encoder = Files.readString(Path.of("src", "main", "resources", "logback-encoder-masking.xml"));
+        assertTrue(encoder.contains("MaskingJsonGeneratorDecorator"));
+        assertTrue(encoder.contains("<path>authorization</path>"));
+        assertTrue(encoder.contains("<path>password</path>"));
+        assertTrue(encoder.contains("<path>token</path>"));
+        assertTrue(encoder.contains("<path>identityToken</path>"));
+    }
+
+    @Test
+    void regexRulesMaskSecretsAndKeepOrdinaryTextReadable() {
+        String withBearer = "Authorization: Bearer superSecretTokenValue";
+        String maskedBearer = withBearer.replaceAll(BEARER_REGEX, BEARER_MASK);
+        assertTrue(maskedBearer.contains("Bearer [REDACTED]"));
+
+        String withKv = "token=abc123 password=qwerty authorization=BasicZXhhbXBsZQ==";
+        String maskedKv = withKv.replaceAll(KV_REGEX, KV_MASK);
+        assertTrue(maskedKv.contains("token=[REDACTED]"));
+        assertTrue(maskedKv.contains("password=[REDACTED]"));
+        assertTrue(maskedKv.contains("authorization=[REDACTED]"));
+
+        String normalLine = "event=manifest.fetch result=success duration_ms=15";
+        String once = normalLine.replaceAll(BEARER_REGEX, BEARER_MASK);
+        String twice = once.replaceAll(KV_REGEX, KV_MASK);
+        assertEquals(normalLine, twice);
+    }
+}

--- a/src/test/moduled/java/riid/core/logging/LogbackMaskingRulesTest.java
+++ b/src/test/moduled/java/riid/core/logging/LogbackMaskingRulesTest.java
@@ -19,15 +19,17 @@ class LogbackMaskingRulesTest {
     @Test
     void logbackConfigContainsMaskingDecoratorAndPaths() throws IOException {
         String root = Files.readString(Path.of("src", "main", "resources", "logback.xml"));
-        assertTrue(root.contains("include resource=\"logback-encoder-masking.xml\""),
-                "logback.xml must include shared encoder/masking fragment");
+        assertTrue(root.contains("include resource=\"logback-encoder-masking.xml\""));
+        assertTrue(root.contains("appender-ref ref=\"STDOUT_JSON\""));
 
-        String encoder = Files.readString(Path.of("src", "main", "resources", "logback-encoder-masking.xml"));
-        assertTrue(encoder.contains("MaskingJsonGeneratorDecorator"));
-        assertTrue(encoder.contains("<path>authorization</path>"));
-        assertTrue(encoder.contains("<path>password</path>"));
-        assertTrue(encoder.contains("<path>token</path>"));
-        assertTrue(encoder.contains("<path>identityToken</path>"));
+        String fragment = Files.readString(Path.of("src", "main", "resources", "logback-encoder-masking.xml"));
+        assertTrue(fragment.contains("ConsoleAppender"));
+        assertTrue(fragment.contains("LogstashEncoder"));
+        assertTrue(fragment.contains("MaskingJsonGeneratorDecorator"));
+        assertTrue(fragment.contains("<path>authorization</path>"));
+        assertTrue(fragment.contains("<path>password</path>"));
+        assertTrue(fragment.contains("<path>token</path>"));
+        assertTrue(fragment.contains("<path>identityToken</path>"));
     }
 
     @Test

--- a/src/test/moduled/java/riid/core/logging/MilestoneEventLoggerTest.java
+++ b/src/test/moduled/java/riid/core/logging/MilestoneEventLoggerTest.java
@@ -1,0 +1,164 @@
+package riid.core.logging;
+
+import java.lang.reflect.Proxy;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.Marker;
+import org.slf4j.spi.LoggingEventBuilder;
+
+class MilestoneEventLoggerTest {
+    @Test
+    void stepSuccessContainsEventResultAndDuration() {
+        CapturingBuilder builder = new CapturingBuilder();
+        Logger logger = loggerWithBuilder(builder);
+
+        MilestoneEventLogger.info(logger)
+                .addEvent("manifest.fetch")
+                .addResult("success")
+                .addDurationMs(42L)
+                .log("Manifest fetched");
+
+        assertEquals("manifest.fetch", builder.keyValues.get(LogContextKeys.EVENT));
+        assertEquals("success", builder.keyValues.get(LogContextKeys.RESULT));
+        assertEquals(42L, builder.keyValues.get(LogContextKeys.DURATION_MS));
+        assertEquals("Manifest fetched", builder.message);
+    }
+
+    @Test
+    void errorBranchContainsKindCodeAndCause() {
+        CapturingBuilder builder = new CapturingBuilder();
+        Logger logger = loggerWithBuilder(builder);
+        RuntimeException failure = new RuntimeException("boom");
+
+        MilestoneEventLogger.error(logger)
+                .addCause(failure)
+                .addEvent("engine.import")
+                .addResult("error")
+                .addDurationMs(5L)
+                .addErrorKind("RUNTIME")
+                .addErrorCode("LOAD_FAILED")
+                .log("Runtime import failed");
+
+        assertEquals("engine.import", builder.keyValues.get(LogContextKeys.EVENT));
+        assertEquals("error", builder.keyValues.get(LogContextKeys.RESULT));
+        assertEquals(5L, builder.keyValues.get(LogContextKeys.DURATION_MS));
+        assertEquals("RUNTIME", builder.keyValues.get(LogContextKeys.ERROR_KIND));
+        assertEquals("LOAD_FAILED", builder.keyValues.get(LogContextKeys.ERROR_CODE));
+        assertEquals("Runtime import failed", builder.message);
+        assertSame(failure, builder.cause);
+    }
+
+    private static Logger loggerWithBuilder(CapturingBuilder builder) {
+        return (Logger) Proxy.newProxyInstance(
+                Logger.class.getClassLoader(),
+                new Class<?>[]{Logger.class},
+                (proxy, method, args) -> {
+                    String name = method.getName();
+                    if ("atInfo".equals(name) || "atWarn".equals(name) || "atError".equals(name)) {
+                        return builder;
+                    }
+                    if ("isEnabledForLevel".equals(name)) {
+                        return true;
+                    }
+                    if ("getName".equals(name)) {
+                        return "test-logger";
+                    }
+                    Class<?> returnType = method.getReturnType();
+                    if (returnType.equals(boolean.class)) {
+                        return true;
+                    }
+                    if (returnType.equals(void.class)) {
+                        return null;
+                    }
+                    return null;
+                });
+    }
+
+    private static final class CapturingBuilder implements LoggingEventBuilder {
+        private final Map<String, Object> keyValues = new LinkedHashMap<>();
+        private Throwable cause;
+        private String message;
+
+        @Override
+        public LoggingEventBuilder setCause(Throwable cause) {
+            this.cause = cause;
+            return this;
+        }
+
+        @Override
+        public LoggingEventBuilder addMarker(Marker marker) {
+            return this;
+        }
+
+        @Override
+        public LoggingEventBuilder addArgument(Object p) {
+            return this;
+        }
+
+        @Override
+        public LoggingEventBuilder addArgument(java.util.function.Supplier<?> objectSupplier) {
+            return this;
+        }
+
+        @Override
+        public LoggingEventBuilder addKeyValue(String key, Object value) {
+            keyValues.put(key, value);
+            return this;
+        }
+
+        @Override
+        public LoggingEventBuilder addKeyValue(String key, java.util.function.Supplier<Object> valueSupplier) {
+            keyValues.put(key, valueSupplier.get());
+            return this;
+        }
+
+        @Override
+        public LoggingEventBuilder setMessage(String message) {
+            this.message = message;
+            return this;
+        }
+
+        @Override
+        public LoggingEventBuilder setMessage(java.util.function.Supplier<String> messageSupplier) {
+            this.message = messageSupplier.get();
+            return this;
+        }
+
+        @Override
+        public void log() {
+            // no-op
+        }
+
+        @Override
+        public void log(String message) {
+            this.message = message;
+        }
+
+        @Override
+        public void log(String format, Object arg) {
+            this.message = format + " " + arg;
+        }
+
+        @Override
+        public void log(String format, Object arg0, Object arg1) {
+            this.message = format + " " + arg0 + " " + arg1;
+        }
+
+        @Override
+        public void log(String format, Object... arguments) {
+            this.message = format;
+        }
+
+        @Override
+        public void log(java.util.function.Supplier<String> messageSupplier) {
+            this.message = messageSupplier.get();
+        }
+    }
+}

--- a/src/test/moduled/java/riid/dispatcher/SimpleRequestDispatcherTest.java
+++ b/src/test/moduled/java/riid/dispatcher/SimpleRequestDispatcherTest.java
@@ -28,6 +28,7 @@ import riid.client.api.RegistryClient;
 import riid.core.model.manifest.Descriptor;
 import riid.core.model.manifest.Manifest;
 import riid.core.model.manifest.TagList;
+import riid.dispatcher.core.config.DispatcherConfig;
 import riid.dispatcher.model.FetchResult;
 import riid.dispatcher.model.ImageRef;
 import riid.p2p.P2PExecutor;
@@ -92,7 +93,7 @@ class SimpleRequestDispatcherTest {
             RecordingP2PExecutor p2p = new RecordingP2PExecutor();
 
             SimpleRequestDispatcher dispatcher = new SimpleRequestDispatcher(
-                    registry, cache, p2p, new DispatcherConfig(1), fs);
+                    registry, cache, p2p, new riid.dispatcher.core.config.DispatcherConfig(1), fs);
             FetchResult result = dispatcher.fetchImage(new ImageRef(REPO, TAG, null));
 
             assertEquals(cachedPath, result.path());

--- a/src/test/moduled/resources/logback-redaction-test.xml
+++ b/src/test/moduled/resources/logback-redaction-test.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Minimal config for LogRedactionTest: FileAppender + masked JSON; keys must be listed for LogstashEncoder. -->
+<configuration>
+    <appender name="FILE" class="ch.qos.logback.core.FileAppender">
+        <file>${redaction.log.path}</file>
+        <append>false</append>
+        <encoder class="net.logstash.logback.encoder.LogstashEncoder">
+            <fieldNames>
+                <timestamp>timestamp</timestamp>
+                <version>[ignore]</version>
+            </fieldNames>
+            <decorator class="net.logstash.logback.mask.MaskingJsonGeneratorDecorator">
+                <defaultMask>[REDACTED]</defaultMask>
+                <path>authorization</path>
+                <path>password</path>
+                <path>token</path>
+                <path>identityToken</path>
+            </decorator>
+            <includeKeyValueKeyName>password</includeKeyValueKeyName>
+            <includeKeyValueKeyName>token</includeKeyValueKeyName>
+            <includeKeyValueKeyName>authorization</includeKeyValueKeyName>
+        </encoder>
+    </appender>
+    <root level="INFO">
+        <appender-ref ref="FILE"/>
+    </root>
+</configuration>

--- a/src/testFixtures/java/riid/logging/TestRootLoggerEvents.java
+++ b/src/testFixtures/java/riid/logging/TestRootLoggerEvents.java
@@ -1,0 +1,109 @@
+package riid.logging;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+import org.slf4j.LoggerFactory;
+import org.slf4j.event.KeyValuePair;
+
+/**
+ * Attaches Logback {@code ListAppender} to the root logger to capture {@code ILoggingEvent}s
+ * without a compile dependency on {@code ch.qos.logback.*} (works in integration/moduled source sets).
+ */
+public final class TestRootLoggerEvents implements AutoCloseable {
+
+    private static final String DEFAULT_APPENDER_NAME = "test-root-list-capture";
+
+    private final Object appender;
+
+    private TestRootLoggerEvents(Object appender) {
+        this.appender = appender;
+    }
+
+    public static TestRootLoggerEvents attach() throws ReflectiveOperationException {
+        return attach(DEFAULT_APPENDER_NAME);
+    }
+
+    public static TestRootLoggerEvents attach(String appenderName) throws ReflectiveOperationException {
+        Object context = LoggerFactory.getILoggerFactory();
+        Object rootLogger = invoke(context, "getLogger", org.slf4j.Logger.ROOT_LOGGER_NAME);
+        Class<?> appenderClass = Class.forName("ch.qos.logback.core.read.ListAppender");
+        Object listAppender = appenderClass.getDeclaredConstructor().newInstance();
+        invoke(listAppender, "setName", appenderName);
+        invoke(listAppender, "setContext", context);
+        invoke(listAppender, "start");
+        invoke(rootLogger, "addAppender", listAppender);
+        return new TestRootLoggerEvents(listAppender);
+    }
+
+    @Override
+    public void close() throws ReflectiveOperationException {
+        detach();
+    }
+
+    public void detach() throws ReflectiveOperationException {
+        Object context = LoggerFactory.getILoggerFactory();
+        Object rootLogger = invoke(context, "getLogger", org.slf4j.Logger.ROOT_LOGGER_NAME);
+        invoke(rootLogger, "detachAppender", appender);
+        invoke(appender, "stop");
+    }
+
+    @SuppressWarnings("unchecked")
+    public List<Object> events() throws ReflectiveOperationException {
+        Field listField = appender.getClass().getField("list");
+        return (List<Object>) listField.get(appender);
+    }
+
+    public static String keyValue(Object event, String key) {
+        List<?> pairs;
+        try {
+            pairs = (List<?>) invoke(event, "getKeyValuePairs");
+        } catch (ReflectiveOperationException | ClassCastException e) {
+            return null;
+        }
+        if (pairs == null) {
+            return null;
+        }
+        for (Object pairObj : pairs) {
+            if (!(pairObj instanceof KeyValuePair pair)) {
+                continue;
+            }
+            if (Objects.equals(key, pair.key)) {
+                return pair.value == null ? null : pair.value.toString();
+            }
+        }
+        return null;
+    }
+
+    @SuppressWarnings("unchecked")
+    public static Map<String, String> mdcPropertyMap(Object event) throws ReflectiveOperationException {
+        return (Map<String, String>) invoke(event, "getMDCPropertyMap");
+    }
+
+    private static Object invoke(Object target, String methodName, Object... args) throws ReflectiveOperationException {
+        Class<?>[] argTypes = new Class<?>[args.length];
+        for (int i = 0; i < args.length; i++) {
+            argTypes[i] = args[i].getClass();
+        }
+        Method method;
+        try {
+            method = target.getClass().getMethod(methodName, argTypes);
+        } catch (NoSuchMethodException ex) {
+            method = findCompatibleMethod(target.getClass(), methodName, args.length);
+        }
+        method.setAccessible(true);
+        return method.invoke(target, args);
+    }
+
+    private static Method findCompatibleMethod(Class<?> type, String methodName, int argCount) throws NoSuchMethodException {
+        for (Method method : type.getMethods()) {
+            if (method.getName().equals(methodName) && method.getParameterCount() == argCount) {
+                return method;
+            }
+        }
+        throw new NoSuchMethodException(type.getName() + "#" + methodName);
+    }
+}

--- a/src/testFixtures/java/riid/logging/TestRootLoggerEvents.java
+++ b/src/testFixtures/java/riid/logging/TestRootLoggerEvents.java
@@ -83,6 +83,10 @@ public final class TestRootLoggerEvents implements AutoCloseable {
         return (Map<String, String>) invoke(event, "getMDCPropertyMap");
     }
 
+    public static String loggerName(Object event) throws ReflectiveOperationException {
+        return (String) invoke(event, "getLoggerName");
+    }
+
     private static Object invoke(Object target, String methodName, Object... args) throws ReflectiveOperationException {
         Class<?>[] argTypes = new Class<?>[args.length];
         for (int i = 0; i < args.length; i++) {


### PR DESCRIPTION
Stack: SLF4J 2 + Logback + logstash-logback-encoder (replace secrets)
# Changes: 
Add structured logging. One json with logging fields.
Trace id at begin of operation via MDC. Also MDC manages operation and component of current log.
Milestones - each logic step of download have log with duration or error code+msg. Add in Dispatcher and App module.
Logback xml configs for tests and main
Add wrappers for MDC in core/logging.
Redaction secrets via masking(path + value regex)
# Tests
unit for redaction&fields ,e2e update ,manual smoke
# Docs
Update logs-oplicy.
In future: Not check project for not given private info(full path/command in log, etc) because not end of dev.